### PR TITLE
process_cpu_isolate_enter: fix leak and incorrect earlier fix

### DIFF
--- a/src/lpmd_cpu.c
+++ b/src/lpmd_cpu.c
@@ -1187,6 +1187,7 @@ static int process_cpu_isolate_enter(void)
 			return ret;
 		}
 		lpmd_log_info ("\tCreate %s\n", "/sys/fs/cgroup/lpm");
+	} else {
 		closedir (dir);
 	}
 


### PR DESCRIPTION
The fix in commit 3fe9bf7d8574 ("process_cpu_isolate_enter: don't closedir on a null dir pointer") closes an unopened directory pointer and does not close an opened directory pointer. Fix this.