### PR TITLE
intel_lpmd: intel_lpmd 0.0.2 release

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -1,7 +1,7 @@
 AC_PREREQ(1.0)
 
 m4_define([lpmd_major_version], [0])
-m4_define([lpmd_minor_version], [0.1])
+m4_define([lpmd_minor_version], [0.2])
 m4_define([lpmd_version],
           [lpmd_major_version.lpmd_minor_version])
 


### PR DESCRIPTION
Release 0.0.2 after a series of cleanups/fixes.