### PR TITLE
intel_lpmd 0.03 release

### DIFF
--- a/Makefile.am
+++ b/Makefile.am
@@ -39,7 +39,8 @@ intel_lpmd_LDADD = \
 	$(SYSTEMD_LIBS)
 
 BUILT_SOURCES = \
-	intel_lpmd_dbus_interface.h
+	intel_lpmd_dbus_interface.h	\
+	lpmd-resource.c
 
 intel_lpmd_SOURCES = \
 	src/lpmd_main.c \
@@ -51,12 +52,17 @@ intel_lpmd_SOURCES = \
 	src/lpmd_hfi.c \
 	src/lpmd_irq.c \
 	src/lpmd_socket.c \
-	src/lpmd_util.c
+	src/lpmd_util.c	\
+	lpmd-resource.c
 
 man8_MANS = man/intel_lpmd.8
 man5_MANS = man/intel_lpmd_config.xml.5
 
 intel_lpmd_dbus_interface.h: $(top_srcdir)/src/intel_lpmd_dbus_interface.xml
 	$(AM_V_GEN) dbus-binding-tool --prefix=dbus_interface --mode=glib-server --output=$@ $<
+
+lpmd-resource.c: $(top_srcdir)/lpmd-resource.gresource.xml
+	$(AM_V_GEN) glib-compile-resources --generate-source lpmd-resource.gresource.xml
+
 
 CLEANFILES = $(BUILT_SOURCES)

--- a/configure.ac
+++ b/configure.ac
@@ -1,7 +1,7 @@
 AC_PREREQ(1.0)
 
 m4_define([lpmd_major_version], [0])
-m4_define([lpmd_minor_version], [0.2])
+m4_define([lpmd_minor_version], [0.3])
 m4_define([lpmd_version],
           [lpmd_major_version.lpmd_minor_version])
 

--- a/configure.ac
+++ b/configure.ac
@@ -96,4 +96,10 @@ AS_IF([test "x$enable_werror" != "xno"], [CFLAGS="$CFLAGS -Werror"])
 AC_CONFIG_FILES([Makefile
                  data/Makefile])
 
+AC_ARG_ENABLE(gdbus,
+              [AS_HELP_STRING([--disable-gdbus],
+                              [Switch DBus backend to glib-dbus. (Default: GDBus)])],
+              [],
+              [AC_DEFINE([GDBUS], [1], [Enable GDBus support])])
+
 AC_OUTPUT

--- a/lpmd-resource.gresource.xml
+++ b/lpmd-resource.gresource.xml
@@ -1,0 +1,6 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<gresources>
+  <gresource prefix="/org/freedesktop/intel_lpmd">
+    <file preprocess="xml-stripblanks">src/intel_lpmd_dbus_interface.xml</file>
+  </gresource>
+</gresources>

--- a/src/lpmd.h
+++ b/src/lpmd.h
@@ -182,6 +182,8 @@ void set_ignore_itmt(void);
 
 int process_lpm(enum lpm_command cmd);
 int process_lpm_unlock(enum lpm_command cmd);
+int freeze_lpm(void);
+int restore_lpm(void);
 
 void lpmd_terminate(void);
 void lpmd_force_on(void);

--- a/src/lpmd.h
+++ b/src/lpmd.h
@@ -181,8 +181,7 @@ int get_util_exit_hyst(void);
 void set_ignore_itmt(void);
 
 int process_lpm(enum lpm_command cmd);
-int enter_lpm(enum lpm_command cmd);
-int exit_lpm(enum lpm_command cmd);
+int process_lpm_unlock(enum lpm_command cmd);
 
 void lpmd_terminate(void);
 void lpmd_force_on(void);

--- a/src/lpmd.h
+++ b/src/lpmd.h
@@ -221,6 +221,8 @@ int has_cpus(enum cpumask_idx idx);
 int add_cpu(int cpu, enum cpumask_idx idx);
 void reset_cpus(enum cpumask_idx idx);
 int set_lpm_cpus(enum cpumask_idx new);
+int uevent_init(void);
+int check_cpu_hotplug(void);
 
 /* cpu.c : APIs for SUV mode support */
 int process_suv_mode(enum lpm_command cmd);

--- a/src/lpmd_cpu.c
+++ b/src/lpmd_cpu.c
@@ -552,14 +552,14 @@ free:
 	/* CPU Hotplug detected, should freeze lpmd */
 	if (!CPU_EQUAL_S (size_cpumask, curr, cpumasks[CPUMASK_ONLINE].mask)) {
 		lpmd_log_debug ("check_cpu_hotplug: CPU Hotplug detected, freeze lpmd\n");
-		return 1;
+		return freeze_lpm ();
 	}
 
 	/* CPU restored to original state, should restore lpmd */
 	if (CPU_EQUAL_S (size_cpumask, curr, cpumasks[CPUMASK_ONLINE].mask) &&
 	    !CPU_EQUAL_S (size_cpumask, curr, prev)) {
 		lpmd_log_debug ("check_cpu_hotplug: CPU Hotplug restored, restore lpmd\n");
-		return -1;
+		return restore_lpm ();
 	}
 
 	/* No update since last change */

--- a/src/lpmd_cpu.c
+++ b/src/lpmd_cpu.c
@@ -1351,7 +1351,7 @@ static int enter_suv_mode(enum lpm_command cmd)
 	 * system is already in LPM.
 	 */
 	if (get_cpu_mode () == LPM_CPU_POWERCLAMP)
-		exit_lpm (cmd);
+		process_lpm_unlock (cmd);
 
 	lpmd_log_info ("------ Enter %s Survivability Mode ---\n", name);
 	ret = _process_cpu_powerclamp_enter (cpumask_str, SUV_IDLE_PCT, -1);
@@ -1387,7 +1387,7 @@ static int exit_suv_mode(enum lpm_command cmd)
 
 //	 Try to re-enter in case it was FORCED ON
 	if (get_cpu_mode () == LPM_CPU_POWERCLAMP)
-		enter_lpm (cmd);
+		process_lpm_unlock (cmd);
 	in_suv = 0;
 
 	return LPMD_SUCCESS;

--- a/src/lpmd_dbus_server.c
+++ b/src/lpmd_dbus_server.c
@@ -130,6 +130,195 @@ static gboolean dbus_interface_s_uv__mo_de__ex_it(PrefObject *obj, GError **erro
 	return TRUE;
 }
 
+#ifdef GDBUS
+#pragma GCC diagnostic push
+
+static GDBusInterfaceVTable interface_vtable;
+extern gint watcher_id;
+
+static GDBusNodeInfo *
+lpmd_dbus_load_introspection(const gchar *filename, GError **error)
+{
+	g_autoptr(GBytes) data = NULL;
+	g_autofree gchar *path = NULL;
+
+	path = g_build_filename("/org/freedesktop/intel_lpmd", filename, NULL);
+	data = g_resources_lookup_data(path, G_RESOURCE_LOOKUP_FLAGS_NONE, error);
+	if (data == NULL)
+		return NULL;
+
+	return g_dbus_node_info_new_for_xml((gchar *)g_bytes_get_data(data, NULL), error);
+}
+
+
+static void
+lpmd_dbus_handle_method_call(GDBusConnection       *connection,
+			    const gchar           *sender,
+			    const gchar           *object_path,
+			    const gchar           *interface_name,
+			    const gchar           *method_name,
+			    GVariant              *parameters,
+			    GDBusMethodInvocation *invocation,
+			    gpointer               user_data)
+{
+	PrefObject *obj = PREF_OBJECT(user_data);
+	g_autoptr(GError) error = NULL;
+
+	lpmd_log_debug("Dbus method called %s %s.\n", interface_name, method_name);
+
+	if (g_strcmp0(method_name, "Terminate") == 0) {
+		g_dbus_method_invocation_return_value(invocation, NULL);
+		dbus_interface_terminate(obj, &error);
+		return;
+	}
+
+	if (g_strcmp0(method_name, "LPM_FORCE_ON") == 0) {
+		g_dbus_method_invocation_return_value(invocation, NULL);
+		dbus_interface_l_pm__fo_rc_e__on(obj, &error);
+		return;
+	}
+
+	if (g_strcmp0(method_name, "LPM_FORCE_OFF") == 0) {
+		g_dbus_method_invocation_return_value(invocation, NULL);
+		dbus_interface_l_pm__fo_rc_e__of_f(obj, &error);
+		return;
+	}
+	if (g_strcmp0(method_name, "LPM_AUTO") == 0) {
+		g_dbus_method_invocation_return_value(invocation, NULL);
+		dbus_interface_l_pm__au_to(obj, &error);
+		return;
+	}
+	if (g_strcmp0(method_name, "SUV_MODE_ENTER") == 0) {
+		g_dbus_method_invocation_return_value(invocation, NULL);
+		dbus_interface_s_uv__mo_de__en_te_r(obj, &error);
+		return;
+	}
+	if (g_strcmp0(method_name, "SUV_MODE_EXIT") == 0) {
+		g_dbus_method_invocation_return_value(invocation, NULL);
+		dbus_interface_s_uv__mo_de__ex_it(obj, &error);
+		return;
+	}
+
+	g_set_error(&error,
+		    G_DBUS_ERROR,
+		    G_DBUS_ERROR_UNKNOWN_METHOD,
+		    "no such method %s",
+		    method_name);
+	g_dbus_method_invocation_return_gerror(invocation, error);
+}
+
+static GVariant *
+lpmd_dbus_handle_get_property(GDBusConnection  *connection,
+			     const gchar      *sender,
+			     const gchar      *object_path,
+			     const gchar      *interface_name,
+			     const gchar      *property_name,
+			     GError          **error,
+			     gpointer          user_data)
+{
+	return NULL;
+}
+
+static gboolean
+lpmd_dbus_handle_set_property(GDBusConnection  *connection,
+			     const gchar      *sender,
+			     const gchar      *object_path,
+			     const gchar      *interface_name,
+			     const gchar      *property_name,
+			     GVariant         *value,
+			     GError          **error,
+			     gpointer          user_data) {
+	return TRUE;
+}
+
+
+static void
+lpmd_dbus_on_bus_acquired(GDBusConnection *connection,
+			 const gchar     *name,
+			 gpointer         user_data) {
+	guint registration_id;
+	GDBusProxy *proxy_id = NULL;
+	GError *error = NULL;
+	GDBusNodeInfo *introspection_data = NULL;
+
+	if (user_data == NULL) {
+		lpmd_log_error("user_data is NULL\n");
+		return;
+	}
+
+	introspection_data = lpmd_dbus_load_introspection("src/intel_lpmd_dbus_interface.xml",
+							 &error);
+	if (error != NULL) {
+		lpmd_log_error("Couldn't create introspection data: %s:\n",
+			      error->message);
+		return;
+	}
+
+	registration_id = g_dbus_connection_register_object(connection,
+							    "/org/freedesktop/intel_lpmd",
+							    introspection_data->interfaces[0],
+							    &interface_vtable,
+							    user_data,
+							    NULL,
+							    &error);
+
+	proxy_id = g_dbus_proxy_new_sync(connection,
+					 G_DBUS_PROXY_FLAGS_DO_NOT_LOAD_PROPERTIES,
+					 NULL,
+					 "org.freedesktop.DBus",
+					 "/org/freedesktop/DBus",
+					 "org.freedesktop.DBus",
+					 NULL,
+					 &error);
+	g_assert(registration_id > 0);
+	g_assert(proxy_id != NULL);
+}
+
+static void
+lpmd_dbus_on_name_acquired(GDBusConnection *connection,
+			  const gchar     *name,
+			  gpointer         user_data) {
+}
+
+static void
+lpmd_dbus_on_name_lost(GDBusConnection *connection,
+		      const gchar     *name,
+		      gpointer         user_data)
+{
+	g_warning("Lost the name %s\n", name);
+	exit(1);
+}
+
+
+// Set up Dbus server with GDBus
+int intel_dbus_server_init(gboolean (*exit_handler)(void)) {
+	PrefObject *value_obj;
+
+	intel_lpmd_dbus_exit_callback = exit_handler;
+
+	value_obj = PREF_OBJECT(g_object_new(PREF_TYPE_OBJECT, NULL));
+	if (value_obj == NULL) {
+		lpmd_log_error("Failed to create one Value instance:\n");
+		return LPMD_FATAL_ERROR;
+	}
+
+	interface_vtable.method_call = lpmd_dbus_handle_method_call;
+	interface_vtable.get_property = lpmd_dbus_handle_get_property;
+	interface_vtable.set_property = lpmd_dbus_handle_set_property;
+
+	watcher_id = g_bus_own_name(G_BUS_TYPE_SYSTEM,
+				    "org.freedesktop.intel_lpmd",
+				    G_BUS_NAME_OWNER_FLAGS_REPLACE,
+				    lpmd_dbus_on_bus_acquired,
+				    lpmd_dbus_on_name_acquired,
+				    lpmd_dbus_on_name_lost,
+				    g_object_ref(value_obj),
+				    NULL);
+
+	return LPMD_SUCCESS;
+}
+#pragma GCC diagnostic pop
+#else
 int intel_dbus_server_init(gboolean (*exit_handler)(void))
 {
 	DBusGConnection *bus;
@@ -178,3 +367,4 @@ int intel_dbus_server_init(gboolean (*exit_handler)(void))
 
 	return LPMD_SUCCESS;
 }
+#endif

--- a/src/lpmd_dbus_server.c
+++ b/src/lpmd_dbus_server.c
@@ -21,20 +21,21 @@
  * dbus messages.
  */
 
+#include <gio/gio.h>
+#include <glib.h>
+#include <glib/gprintf.h>
+#include <glib-object.h>
+
 #include "lpmd.h"
 
-typedef struct {
+struct _PrefObject {
 	GObject parent;
-} PrefObject;
+};
 
-typedef struct {
-	GObjectClass parent;
-} PrefObjectClass;
-
-GType
-pref_object_get_type(void);
-#define MAX_DBUS_REPLY_STR_LEN	100
 #define PREF_TYPE_OBJECT (pref_object_get_type())
+G_DECLARE_FINAL_TYPE(PrefObject, pref_object, PREF, OBJECT, GObject)
+
+#define MAX_DBUS_REPLY_STR_LEN	100
 G_DEFINE_TYPE(PrefObject, pref_object, G_TYPE_OBJECT)
 
 static gboolean

--- a/src/lpmd_hfi.c
+++ b/src/lpmd_hfi.c
@@ -362,5 +362,5 @@ int hfi_init(void)
 	if (drv.nl_handle)
 		return nl_socket_get_fd (drv.nl_handle);
 
-err_proc: return LPMD_ERROR;
+err_proc: return -1;
 }

--- a/src/lpmd_main.c
+++ b/src/lpmd_main.c
@@ -22,8 +22,11 @@
  * Also allow to daemonize.
  */
 
+#include <gio/gio.h>
+#include <glib.h>
 #include <glib-unix.h>
 #include <syslog.h>
+
 
 #include "lpmd.h"
 
@@ -56,6 +59,10 @@ static gboolean use_syslog;
 static gboolean dbus_enable;
 
 static GMainLoop *g_main_loop;
+
+#ifdef GDBUS
+gint watcher_id = 0;
+#endif
 
 // g_log handler. All logs will be directed here
 static void intel_lpmd_logger(const gchar *log_domain, GLogLevelFlags log_level,
@@ -302,6 +309,10 @@ int main(int argc, char *argv[])
 	lpmd_log_debug ("Start main loop\n");
 	g_main_loop_run (g_main_loop);
 	lpmd_log_warn ("Oops g main loop exit..\n");
+
+#ifdef GDBUS
+	g_bus_unwatch_name (watcher_id);
+#endif
 
 	fprintf (stdout, "Exiting ..\n");
 	clean_up_lockfile ();

--- a/tests/lpm_test_interface.sh
+++ b/tests/lpm_test_interface.sh
@@ -39,27 +39,27 @@ do
 		;;
 	1)
 		echo "1 : Terminate"
-		dbus-send --system --dest=org.freedesktop.intel_lpmd /org/freedesktop/intel_lpmd org.freedesktop.intel_lpmd.Terminate
+		dbus-send --system --dest=org.freedesktop.intel_lpmd --print-reply /org/freedesktop/intel_lpmd org.freedesktop.intel_lpmd.Terminate
 		;;
 	2)
 		echo "2 : LPM force on"
-		dbus-send --system --dest=org.freedesktop.intel_lpmd /org/freedesktop/intel_lpmd org.freedesktop.intel_lpmd.LPM_FORCE_ON
+		dbus-send --system --dest=org.freedesktop.intel_lpmd --print-reply /org/freedesktop/intel_lpmd org.freedesktop.intel_lpmd.LPM_FORCE_ON
 		;;
 	3)
 		echo "3 : LPM force off"
-		dbus-send --system --dest=org.freedesktop.intel_lpmd /org/freedesktop/intel_lpmd org.freedesktop.intel_lpmd.LPM_FORCE_OFF
+		dbus-send --system --dest=org.freedesktop.intel_lpmd --print-reply /org/freedesktop/intel_lpmd org.freedesktop.intel_lpmd.LPM_FORCE_OFF
 		;;
 	4)
 		echo "4 : LPM auto"
-		dbus-send --system --dest=org.freedesktop.intel_lpmd /org/freedesktop/intel_lpmd org.freedesktop.intel_lpmd.LPM_AUTO
+		dbus-send --system --dest=org.freedesktop.intel_lpmd --print-reply /org/freedesktop/intel_lpmd org.freedesktop.intel_lpmd.LPM_AUTO
 		;;
 	5)
 		echo "5 : SUV_MODE Enter"
-		dbus-send --system --dest=org.freedesktop.intel_lpmd /org/freedesktop/intel_lpmd org.freedesktop.intel_lpmd.SUV_MODE_ENTER
+		dbus-send --system --dest=org.freedesktop.intel_lpmd --print-reply /org/freedesktop/intel_lpmd org.freedesktop.intel_lpmd.SUV_MODE_ENTER
 		;;
 	6)
 		echo "6 : SUV_MODE Exit"
-		dbus-send --system --dest=org.freedesktop.intel_lpmd /org/freedesktop/intel_lpmd org.freedesktop.intel_lpmd.SUV_MODE_EXIT
+		dbus-send --system --dest=org.freedesktop.intel_lpmd --print-reply /org/freedesktop/intel_lpmd org.freedesktop.intel_lpmd.SUV_MODE_EXIT
 		;;
 	7)
 		exit 0


### PR DESCRIPTION
    Release 0.0.3, including
    
    1. Conversion from glib-dbus to GDBus.
    
    2. Add handling for CPU hotplug.
    
    3. Use strict CPU model check to allow intel_lpmd running on
       1.1 validated platforms only. Including ADL/RPL/MTL for now.
       1.2 CPUID.7 Hybrid bit is set
       1.3 /sys/firmware/acpi/pm_profile returns 2 (mobile platform)
    
    4. Use cpuid() to detect Lcores instead of using cache sysfs.
    
    5. Enhance Ecore module detection
    
    6. Fix pthread error handling, suggested by ColinIanKing.
    
    7. Werror Fixes from aekoroglu.
