### PR TITLE
lpmd_cpu: ensure online is initialized to zero

### DIFF
--- a/src/lpmd_cpu.c
+++ b/src/lpmd_cpu.c
@@ -675,7 +675,7 @@ static int parse_cpu_topology(void)
 
 	reset_cpus (CPUMASK_ONLINE);
 	for (i = 0; i < topo_max_cpus; i++) {
-		unsigned int online;
+		unsigned int online = 0;
 
 		snprintf (path, sizeof(path), "/sys/devices/system/cpu/cpu%d/online", i);
 		filep = fopen (path, "r");


### PR DESCRIPTION
If the fscanf fails we end up with online in a undefined uninitalized state. Fix this by initializing online to zero.

Cleans up clang scan build warning:

src/lpmd_cpu.c:692:7: warning: Branch condition evaluates to a garbage value [core.uninitialized.Branch]
  692 |                 if (!online)
      |                     ^~~~~~~