### PR TITLE
Revert "automake and autoconf improvements"

### DIFF
--- a/Makefile.am
+++ b/Makefile.am
@@ -1,31 +1,33 @@
-SUBDIRS = data
+include $(GLIB_MAKEFILE)
 
-# Programs to build
-sbin_PROGRAMS = \
-	intel_lpmd
+SUBDIRS = . data tools
 
-bin_PROGRAMS = \
-	intel_lpmd_control
+ACLOCAL_AMFLAGS =
 
-intel_lpmd_CPPFLAGS = \
-	$(DBUS_CFLAGS) \
-	$(GLIB_CFLAGS) \
-	$(LIBDL) \
-	$(LIBM) \
-	$(LIBNL_CFLAGS) \
-	$(SYSTEMD_CFLAGS) \
+# Global C Flags
+AM_CFLAGS = \
+	${DBUS_CFLAGS} \
 	$(XML_CFLAGS) \
+	-DTDRUNDIR=\"$(lpmd_rundir)\" \
+	-DTDCONFDIR=\"$(lpmd_confdir)\" \
+	$(CFLAGS) \
 	$(libnl30_CFLAGS)\
 	$(libnlgenl30_CFLAGS) \
-	-DGLIB_SUPPORT \
-	-DTDCONFDIR=\"$(lpmd_confdir)\" \
+	$(SYSTEMD_CFLAGS) \
+	-I src
+
+EXTRA_DIST=Makefile.glib \
+	intel_lpmd.pc.in
+
+# Programs to build
+sbin_PROGRAMS = intel_lpmd
+
+intel_lpmd_CPPFLAGS = \
+	-I@top_srcdir@/src \
 	-DTDLOCALEDIR=\"$(datadir)/locale\" \
-	-DTDRUNDIR=\"$(lpmd_rundir)\" \
-	-I$(top_srcdir)/src
+	-DGLIB_SUPPORT
 
-intel_lpmd_CFLAGS = \
-	-I$(top_srcdir)/src
-
+intel_lpmd_includedir = @top_srcdir@
 intel_lpmd_LDADD = \
 	$(DBUS_LIBS) \
 	$(GLIB_LIBS) \
@@ -36,17 +38,8 @@ intel_lpmd_LDADD = \
 	$(libnlgenl30_LIBS) \
 	$(SYSTEMD_LIBS)
 
-intel_lpmd_control_CFLAGS = \
-	$(DBUS_GLIB_CFLAGS)
-
-intel_lpmd_control_LDADD = \
-	$(DBUS_GLIB_LIBS)
-
-intel_lpmd_control_SOURCES = \
-	tools/intel_lpmd_control.c
-
 BUILT_SOURCES = \
-	intel_lpmd_dbus_interface.h \
+	intel_lpmd_dbus_interface.h	\
 	lpmd-resource.c
 
 intel_lpmd_SOURCES = \
@@ -62,9 +55,8 @@ intel_lpmd_SOURCES = \
 	src/lpmd_util.c	\
 	lpmd-resource.c
 
-man_MANS = \
-	man/intel_lpmd.8 \
-	man/intel_lpmd_config.xml.5
+man8_MANS = man/intel_lpmd.8
+man5_MANS = man/intel_lpmd_config.xml.5
 
 intel_lpmd_dbus_interface.h: $(top_srcdir)/src/intel_lpmd_dbus_interface.xml
 	$(AM_V_GEN) dbus-binding-tool --prefix=dbus_interface --mode=glib-server --output=$@ $<

--- a/configure.ac
+++ b/configure.ac
@@ -1,4 +1,4 @@
-AC_PREREQ([2.70])
+AC_PREREQ(1.0)
 
 m4_define([lpmd_major_version], [0])
 m4_define([lpmd_minor_version], [0.3])
@@ -6,29 +6,29 @@ m4_define([lpmd_version],
           [lpmd_major_version.lpmd_minor_version])
 
 AC_INIT([intel_lpmd], [lpmd_version], [], [intel_lpmd])
-m4_ifdef([AM_SILENT_RULES], [AM_SILENT_RULES([yes])])
+m4_ifdef([AM_SILENT_RULES],[AM_SILENT_RULES([yes])])
 
 AC_CONFIG_MACRO_DIR([m4])
 AC_CONFIG_AUX_DIR(build-aux)
 AC_CONFIG_HEADERS([config.h])
 
 AM_INIT_AUTOMAKE([1.11 foreign no-define subdir-objects])
-AM_MAINTAINER_MODE([disable])
+AM_MAINTAINER_MODE([enable])
 
-GTK_DOC_CHECK([1.11], [--flavour no-tmpl])
+GTK_DOC_CHECK([1.11],[--flavour no-tmpl])
 
 AC_ARG_WITH(dbus-sys-dir, AS_HELP_STRING([--with-dbus-sys-dir=DIR], [where D-BUS system.d directory is]))
 if test -n "$with_dbus_sys_dir" ; then
-	DBUS_SYS_DIR="$with_dbus_sys_dir"
+    DBUS_SYS_DIR="$with_dbus_sys_dir"
 else
-	DBUS_SYS_DIR="/etc/dbus-1/system.d"
+    DBUS_SYS_DIR="/etc/dbus-1/system.d"
 fi
-AC_SUBST([DBUS_SYS_DIR])
+AC_SUBST(DBUS_SYS_DIR)
 
 # paths
-AC_SUBST([lpmd_binary], ["$sbindir/$PACKAGE"], [Binary executable])
-AC_SUBST([lpmd_confdir], ["$sysconfdir/$PACKAGE"], [Configuration directory])
-AC_SUBST([lpmd_rundir], ["$rundir/$PACKAGE"], [Runtime state directory])
+AC_SUBST(lpmd_binary, "$sbindir/$PACKAGE", [Binary executable])
+AC_SUBST(lpmd_confdir, "$sysconfdir/$PACKAGE", [Configuration directory])
+AC_SUBST(lpmd_rundir, "$localstatedir/run/$PACKAGE", [Runtime state directory])
 
 PKG_PROG_PKG_CONFIG
 AC_ARG_WITH([systemdsystemunitdir],
@@ -52,41 +52,37 @@ echo "  lpmd_rundir: $lpmd_rundir"
 echo
 
 GETTEXT_PACKAGE=intel_lpmd
-AC_SUBST([GETTEXT_PACKAGE])
-AC_DEFINE_UNQUOTED([GETTEXT_PACKAGE], ["$GETTEXT_PACKAGE"], [Gettext package])
+AC_SUBST(GETTEXT_PACKAGE)
+AC_DEFINE_UNQUOTED(GETTEXT_PACKAGE,"$GETTEXT_PACKAGE", [Gettext package])
 
 dnl
 dnl Checks for new dbus-glib property access function
 dnl
-PKG_CHECK_MODULES([DBUS_GLIB], [dbus-glib-1 >= 0.94],
-	[dbus_glib_global_set_disable_legacy_property_access],
-	[ac_have_dg_prop="1"], [ac_have_dg_prop="0"]
-)
-AC_DEFINE_UNQUOTED([HAVE_DBUS_GLIB_DISABLE_LEGACY_PROP_ACCESS],
-	[$ac_have_dg_prop],
-	[Define if you have a dbus-glib with dbus_glib_global_set_disable_legacy_property_access()]
-)
+AC_CHECK_LIB([dbus-glib-1], [dbus_glib_global_set_disable_legacy_property_access], ac_have_dg_prop="1", ac_have_dg_prop="0")
+AC_DEFINE_UNQUOTED(HAVE_DBUS_GLIB_DISABLE_LEGACY_PROP_ACCESS, $ac_have_dg_prop, [Define if you have a dbus-glib with dbus_glib_global_set_disable_legacy_property_access()])
 
-PKG_CHECK_MODULES([DBUS], [dbus-1 >= 1.1 dbus-glib-1 >= 0.94])
+PKG_CHECK_MODULES(DBUS, dbus-1 >= 1.1 dbus-glib-1 >= 0.94)
+AC_SUBST(DBUS_CFLAGS)
+AC_SUBST(DBUS_LIBS)
 
 GLIB_VERSION_DEFINES="-DGLIB_VERSION_MIN_REQUIRED=GLIB_VERSION_2_26"
 DBUS_CFLAGS="$DBUS_CFLAGS $GLIB_VERSION_DEFINES"
 
-PKG_CHECK_MODULES([GLIB], [gio-unix-2.0 >= 2.22 gmodule-2.0])
+PKG_CHECK_MODULES(GLIB, gio-unix-2.0 >= 2.22 gmodule-2.0)
 GLIB_CFLAGS="$GLIB_CFLAGS $GLIB_VERSION_DEFINES"
+AC_SUBST(GLIB_CFLAGS)
+AC_SUBST(GLIB_LIBS)
 
-PKG_CHECK_MODULES([XML], [libxml-2.0 >= 2.4])
+PKG_CHECK_MODULES(XML, libxml-2.0 >= 2.4)
 
-PKG_CHECK_MODULES([libnl30], [libnl-3.0], libnl30=yes, libnl30=no)
-PKG_CHECK_MODULES([libnlgenl30], [libnl-genl-3.0], libnlgenl30=yes, libnlgenl30=no)
+PKG_CHECK_MODULES(libnl30, [libnl-3.0], libnl30=yes, libnl30=no)
+PKG_CHECK_MODULES(libnlgenl30, [libnl-genl-3.0], libnlgenl30=yes, libnlgenl30=no)
 
 PKG_CHECK_MODULES([SYSTEMD], [libsystemd], [],
-	[PKG_CHECK_MODULES([SYSTEMD], [libsystemd-daemon], [],
-		AC_MSG_ERROR([libsystemd support requested but found]))
-	]
-)
+      [PKG_CHECK_MODULES([SYSTEMD], [libsystemd-daemon], [],
+       AC_MSG_ERROR([libsystemd support requested but found]))])
 
-AC_PATH_PROG([GDBUS_CODEGEN], [gdbus-codegen])
+AC_PATH_PROG([GDBUS_CODEGEN],[gdbus-codegen])
 
 AC_PROG_CC
 AC_PROG_INSTALL
@@ -98,10 +94,7 @@ AC_ARG_ENABLE(werror, AS_HELP_STRING([--disable-werror], [Disable -Werror]))
 AS_IF([test "x$enable_werror" != "xno"], [CFLAGS="$CFLAGS -Werror"])
 
 AC_CONFIG_FILES([Makefile
-	data/Makefile
-	data/intel_lpmd.service
-	data/org.freedesktop.intel_lpmd.service
-])
+                 data/Makefile])
 
 AC_ARG_ENABLE(gdbus,
               [AS_HELP_STRING([--disable-gdbus],

--- a/data/Makefile.am
+++ b/data/Makefile.am
@@ -1,11 +1,25 @@
+include $(GLIB_MAKEFILE)
+
 if HAVE_SYSTEMD
 systemdsystemunit_DATA = \
 	intel_lpmd.service
 
+intel_lpmd.service: intel_lpmd.service.in
+	@$(edit) $< >$@
+
 servicedir = $(datadir)/dbus-1/system-services
 service_in_files = org.freedesktop.intel_lpmd.service.in
 service_DATA = $(service_in_files:.service.in=.service)
+
+$(service_DATA): $(service_in_files) Makefile
+	@$(edit) $< >$@
 endif
+
+edit = sed \
+	-e 's|@bindir[@]|$(bindir)|g' \
+	-e 's|@sbindir[@]|$(sbindir)|g' \
+	-e 's|@sysconfdir[@]|$(sysconfdir)|g' \
+	-e 's|@localstatedir[@]|$(localstatedir)|g'
 
 dbusservicedir = $(DBUS_SYS_DIR)
 dbusservice_DATA = org.freedesktop.intel_lpmd.conf

--- a/data/org.freedesktop.intel_lpmd.service.in
+++ b/data/org.freedesktop.intel_lpmd.service.in
@@ -1,5 +1,5 @@
 [D-BUS Service]
 Name=org.freedesktop.intel_lpmd
-Exec=/usr/bin/false
+Exec=/bin/false
 User=root
 SystemdService=org.freedesktop.intel_lpmd.service

--- a/tests/lpm_test_interface.sh
+++ b/tests/lpm_test_interface.sh
@@ -1,4 +1,4 @@
-#!/bin/sh
+#!/bin/bash
 
 if [ "$(whoami)" != "root" ]
 then

--- a/tools/Makefile
+++ b/tools/Makefile
@@ -1,0 +1,19 @@
+CFLAGS_DBUS_GLIB = $(shell pkg-config --cflags --libs dbus-glib-1)
+
+bindir ?= /usr/bin
+
+CFLAGS ?= -g -Wall -Werror
+
+all: intel_lpmd_control
+
+intel_lpmd_control: intel_lpmd_control.c
+	gcc $< -o $@ $(CFLAGS) $(CFLAGS_DBUS_GLIB) $(LDFLAGS)
+
+clean:
+	rm -f intel_lpmd_control
+
+install: $(ALL_PROGRAMS)
+	install -d -m 755 $(DESTDIR)$(bindir);          \
+	install intel_lpmd_control $(DESTDIR)$(bindir);
+
+.PHONY: all clean


### PR DESCRIPTION
Reverts intel/intel-lpmd#23
because some of the patches miss "Signed-off-by" tag.