### PR TITLE
Deprecate the dbus-glib dependency

### DIFF
--- a/Makefile.am
+++ b/Makefile.am
@@ -6,7 +6,7 @@ ACLOCAL_AMFLAGS =
 
 # Global C Flags
 AM_CFLAGS = \
-	${DBUS_CFLAGS} \
+	${GLIB_CFLAGS} \
 	$(XML_CFLAGS) \
 	-DTDRUNDIR=\"$(lpmd_rundir)\" \
 	-DTDCONFDIR=\"$(lpmd_confdir)\" \
@@ -29,7 +29,6 @@ intel_lpmd_CPPFLAGS = \
 
 intel_lpmd_includedir = @top_srcdir@
 intel_lpmd_LDADD = \
-	$(DBUS_LIBS) \
 	$(GLIB_LIBS) \
 	$(LIBNL_LIBS) \
 	$(LIBM) \
@@ -39,7 +38,6 @@ intel_lpmd_LDADD = \
 	$(SYSTEMD_LIBS)
 
 BUILT_SOURCES = \
-	intel_lpmd_dbus_interface.h	\
 	lpmd-resource.c
 
 intel_lpmd_SOURCES = \
@@ -57,9 +55,6 @@ intel_lpmd_SOURCES = \
 
 man8_MANS = man/intel_lpmd.8
 man5_MANS = man/intel_lpmd_config.xml.5
-
-intel_lpmd_dbus_interface.h: $(top_srcdir)/src/intel_lpmd_dbus_interface.xml
-	$(AM_V_GEN) dbus-binding-tool --prefix=dbus_interface --mode=glib-server --output=$@ $<
 
 lpmd-resource.c: $(top_srcdir)/lpmd-resource.gresource.xml
 	$(AM_V_GEN) glib-compile-resources --generate-source lpmd-resource.gresource.xml

--- a/configure.ac
+++ b/configure.ac
@@ -55,20 +55,9 @@ GETTEXT_PACKAGE=intel_lpmd
 AC_SUBST(GETTEXT_PACKAGE)
 AC_DEFINE_UNQUOTED(GETTEXT_PACKAGE,"$GETTEXT_PACKAGE", [Gettext package])
 
-dnl
-dnl Checks for new dbus-glib property access function
-dnl
-AC_CHECK_LIB([dbus-glib-1], [dbus_glib_global_set_disable_legacy_property_access], ac_have_dg_prop="1", ac_have_dg_prop="0")
-AC_DEFINE_UNQUOTED(HAVE_DBUS_GLIB_DISABLE_LEGACY_PROP_ACCESS, $ac_have_dg_prop, [Define if you have a dbus-glib with dbus_glib_global_set_disable_legacy_property_access()])
-
-PKG_CHECK_MODULES(DBUS, dbus-1 >= 1.1 dbus-glib-1 >= 0.94)
-AC_SUBST(DBUS_CFLAGS)
-AC_SUBST(DBUS_LIBS)
-
 GLIB_VERSION_DEFINES="-DGLIB_VERSION_MIN_REQUIRED=GLIB_VERSION_2_26"
-DBUS_CFLAGS="$DBUS_CFLAGS $GLIB_VERSION_DEFINES"
 
-PKG_CHECK_MODULES(GLIB, gio-unix-2.0 >= 2.22 gmodule-2.0)
+PKG_CHECK_MODULES(GLIB, gio-unix-2.0 >= 2.22 gmodule-2.0 glib-2.0 gobject-2.0)
 GLIB_CFLAGS="$GLIB_CFLAGS $GLIB_VERSION_DEFINES"
 AC_SUBST(GLIB_CFLAGS)
 AC_SUBST(GLIB_LIBS)

--- a/src/lpmd.h
+++ b/src/lpmd.h
@@ -46,9 +46,6 @@
 
 #ifdef GLIB_SUPPORT
 #include <glib.h>
-#include <dbus/dbus.h>
-#include <dbus/dbus-glib-lowlevel.h>
-#include <dbus/dbus-glib.h>
 #include <glib/gi18n.h>
 #include <gmodule.h>
 

--- a/tools/Makefile
+++ b/tools/Makefile
@@ -1,4 +1,6 @@
-CFLAGS_DBUS_GLIB = $(shell pkg-config --cflags --libs dbus-glib-1)
+CFLAGS_GLIB = $(shell pkg-config --cflags --libs glib-2.0) \
+	      $(shell pkg-config --cflags --libs gio-unix-2.0) \
+	      $(shell pkg-config --cflags --libs gobject-2.0) \
 
 bindir ?= /usr/bin
 
@@ -7,7 +9,7 @@ CFLAGS ?= -g -Wall -Werror
 all: intel_lpmd_control
 
 intel_lpmd_control: intel_lpmd_control.c
-	gcc $< -o $@ $(CFLAGS) $(CFLAGS_DBUS_GLIB) $(LDFLAGS)
+	gcc $< -o $@ $(CFLAGS) $(CFLAGS_GLIB) $(LDFLAGS)
 
 clean:
 	rm -f intel_lpmd_control


### PR DESCRIPTION
Since the dbus-glib was already deprecated, the related portion of codes for lpmd can be removed. This work entirely deprecated dbus-glib and made the dbus implementation based on GDbus.
