### PR TITLE
intel_lpmd 0.0.4 release 

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -1,7 +1,7 @@
 AC_PREREQ([2.70])
 
 m4_define([lpmd_major_version], [0])
-m4_define([lpmd_minor_version], [0.3])
+m4_define([lpmd_minor_version], [0.4])
 m4_define([lpmd_version],
           [lpmd_major_version.lpmd_minor_version])
 

--- a/data/intel_lpmd_config.xml
+++ b/data/intel_lpmd_config.xml
@@ -12,6 +12,13 @@ for Intel Low Power Mode daemon
 	<lp_mode_cpus></lp_mode_cpus>
 
 	<!--
+		EPP to use in Low Power Mode
+		0-255: Valid EPP value to use in Low Power Mode
+		   -1: Don't change EPP in Low Power Mode
+	-->
+	<lp_mode_epp>-1</lp_mode_epp>
+
+	<!--
 		Mode values
 		0: Cgroup v2
 		1: Cgroup v2 isolate
@@ -49,6 +56,13 @@ for Intel Low Power Mode daemon
 		1 : Yes
 	-->
 	<HfiLpmEnable>0</HfiLpmEnable>
+
+	<!--
+		Use WLT hints
+		0 : No
+		1 : Yes
+	-->
+	<WLTHintEnable>0</WLTHintEnable>
 
 	<!--
 		Use HFI SUV hints
@@ -102,5 +116,56 @@ for Intel Low Power Mode daemon
 	-->
 	<IgnoreITMT>0</IgnoreITMT>
 
+	<!--
+		Example Utilization based config states applied to
+		4Pcore-8Ecore-2Lcore 15W TDP Meteor Lake platform.
+	-->
+	<States>
+		<CPUFamily> 6 </CPUFamily>
+		<CPUModel> 186 </CPUModel>
+		<CPUConfig> 8P8E0L-28W </CPUConfig>
+		<State>
+			<ID> 1 </ID>
+			<Name> LPM_DEEP </Name>
+			<EntrySystemLoadThres> 2 </EntrySystemLoadThres>
+			<EnterCPULoadThres> 50 </EnterCPULoadThres>
+			<EPP> -1 </EPP>
+			<EPB> -1 </EPB>
+			<ITMTState> -1 </ITMTState>
+			<IRQMigrate> 1 </IRQMigrate>
+			<ActiveCPUs>14,15</ActiveCPUs>
+			<MinPollInterval> 500 </MinPollInterval>
+			<PollIntervalIncrement> 500 </PollIntervalIncrement>
+			<MaxPollInterval> 2000 </MaxPollInterval>
+		</State>
+		<State>
+			<ID> 2 </ID>
+			<Name> LPM_LOW </Name>
+			<EntrySystemLoadThres> 10 </EntrySystemLoadThres>
+			<ExitSystemLoadhysteresis> 3 </ExitSystemLoadhysteresis>
+			<EPP> -1 </EPP>
+			<EPB> -1 </EPB>
+			<ITMTState> -1 </ITMTState>
+			<IRQMigrate> 1 </IRQMigrate>
+			<ActiveCPUs>10,11,12,13</ActiveCPUs>
+			<MinPollInterval> 1000 </MinPollInterval>
+			<PollIntervalIncrement> 1000 </PollIntervalIncrement>
+			<MaxPollInterval> 3000 </MaxPollInterval>
+		</State>
+		<State>
+			<ID> 3 </ID>
+			<Name> FULL_POWER </Name>
+			<EntrySystemLoadThres></EntrySystemLoadThres>
+			<EnterCPULoadThres></EnterCPULoadThres>
+			<EPP> -1 </EPP>
+			<EPB> -1 </EPB>
+			<ITMTState> -1 </ITMTState>
+			<IRQMigrate> 1 </IRQMigrate>
+			<ActiveCPUs>0-15</ActiveCPUs>
+			<MinPollInterval> 500 </MinPollInterval>
+			<PollIntervalIncrement> -1 </PollIntervalIncrement>
+			<MaxPollInterval> 2000 </MaxPollInterval>
+		</State>
+	</States>
 </Configuration>
 

--- a/data/intel_lpmd_config_examples.xml
+++ b/data/intel_lpmd_config_examples.xml
@@ -1,0 +1,112 @@
+<?xml version="1.0"?>
+
+<!--
+Specifies the configuration data
+for Intel Low Power Mode daemon
+-->
+
+<Configuration>
+	<!--
+		CPU format example: 1,2,4..6,8-10
+	-->
+	<lp_mode_cpus></lp_mode_cpus>
+
+	<!--
+		EPP to use in Low Power Mode
+		0-255: Valid EPP value to use in Low Power Mode
+		   -1: Don't change EPP in Low Power Mode
+	-->
+	<lp_mode_epp>-1</lp_mode_epp>
+
+	<!--
+		Mode values
+		0: Cgroup v2
+		1: Cgroup v2 isolate
+		2: CPU idle injection
+	-->
+	<Mode>0</Mode>
+
+	<!--
+		Default behavior when Performance power setting is used
+		-1: force off. (Never enter Low Power Mode)
+		 1: force on. (Always stay in Low Power Mode)
+		 0: auto. (opportunistic Low Power Mode enter/exit)
+	-->
+	<PerformanceDef>-1</PerformanceDef>
+
+	<!--
+		Default behavior when Balanced power setting is used
+		-1: force off. (Never enter Low Power Mode)
+		 1: force on. (Always stay in Low Power Mode)
+		 0: auto. (opportunistic Low Power Mode enter/exit)
+	-->
+	<BalancedDef>-1</BalancedDef>
+
+	<!--
+		Default behavior when Power saver setting is used
+		-1: force off. (Never enter Low Power Mode)
+		 1: force on. (Always stay in Low Power Mode)
+		 0: auto. (opportunistic Low Power Mode enter/exit)
+	-->
+	<PowersaverDef>-1</PowersaverDef>
+
+	<!--
+		Use HFI LPM hints
+		0 : No
+		1 : Yes
+	-->
+	<HfiLpmEnable>0</HfiLpmEnable>
+
+	<!--
+		Use HFI SUV hints
+		0 : No
+		1 : Yes
+	-->
+	<HfiSuvEnable>0</HfiSuvEnable>
+
+	<!--
+		System utilization threshold to enter LP mode
+		from 0 - 100
+		clear both util_entry_threshold and util_exit_threshold to disable util monitor
+	-->
+	<util_entry_threshold>10</util_entry_threshold>
+
+	<!--
+		System utilization threshold to exit LP mode
+		from 0 - 100
+		clear both util_entry_threshold and util_exit_threshold to disable util monitor
+	-->
+	<util_exit_threshold>95</util_exit_threshold>
+
+	<!--
+		Entry delay. Minimum delay in non Low Power mode to
+		enter LPM mode.
+	-->
+	<EntryDelayMS>0</EntryDelayMS>
+
+	<!--
+		Exit delay. Minimum delay in Low Power mode to
+		exit LPM mode.
+	-->
+	<ExitDelayMS>0</ExitDelayMS>
+
+	<!--
+		Lowest hysteresis average in-LP-mode time in msec to enter LP mode
+		0: to disable hysteresis support
+	-->
+	<EntryHystMS>0</EntryHystMS>
+
+	<!--
+		Lowest hysteresis average out-of-LP-mode time in msec to exit LP mode
+		0: to disable hysteresis support
+	-->
+	<ExitHystMS>0</ExitHystMS>
+
+	<!--
+		Ignore ITMT setting during LP-mode enter/exit
+		0: disable ITMT upon LP-mode enter and re-enable ITMT upon LP-mode exit
+		1: do not touch ITMT setting during LP-mode enter/exit
+	-->
+	<IgnoreITMT>0</IgnoreITMT>
+
+</Configuration>

--- a/data/intel_lpmd_config_examples.xml
+++ b/data/intel_lpmd_config_examples.xml
@@ -109,4 +109,54 @@ for Intel Low Power Mode daemon
 	-->
 	<IgnoreITMT>0</IgnoreITMT>
 
+	<!--
+		Example config states applied to 4Pcore-8Ecore-2Lcore 15W TDP Meteor Lake platform
+	-->
+	<States>
+		<CPUFamily> 6 </CPUFamily>
+		<CPUModel> 170 </CPUModel>
+		<CPUConfig> 4P8E2L-15W </CPUConfig>
+		<State>
+			<ID> 1 </ID>
+			<Name> LPM_DEEP </Name>
+			<EntrySystemLoadThres> 2 </EntrySystemLoadThres>
+			<EnterCPULoadThres> 50 </EnterCPULoadThres>
+			<EPP> -1 </EPP>
+			<EPB> -1 </EPB>
+			<ITMTState> -1 </ITMTState>
+			<IRQMigrate> -1 </IRQMigrate>
+			<ActiveCPUs>16,17</ActiveCPUs>
+			<MinPollInterval> 500 </MinPollInterval>
+			<PollIntervalIncrement> 500 </PollIntervalIncrement>
+			<MaxPollInterval> 2000 </MaxPollInterval>
+		</State>
+		<State>
+			<ID> 2 </ID>
+			<Name> LPM_LOW </Name>
+			<EntrySystemLoadThres> 10 </EntrySystemLoadThres>
+			<ExitSystemLoadhysteresis> 3 </ExitSystemLoadhysteresis>
+			<EPP> -1 </EPP>
+			<EPB> -1 </EPB>
+			<ITMTState> -1 </ITMTState>
+			<IRQMigrate> -1 </IRQMigrate>
+			<ActiveCPUs>12,13,14,15</ActiveCPUs>
+			<MinPollInterval> 1000 </MinPollInterval>
+			<PollIntervalIncrement> 1000 </PollIntervalIncrement>
+			<MaxPollInterval> 3000 </MaxPollInterval>
+		</State>
+		<State>
+			<ID> 3 </ID>
+			<Name> FULL_POWER </Name>
+			<EntrySystemLoadThres></EntrySystemLoadThres>
+			<EnterCPULoadThres></EnterCPULoadThres>
+			<EPP> -1 </EPP>
+			<EPB> -1 </EPB>
+			<ITMTState> -1 </ITMTState>
+			<IRQMigrate> -1 </IRQMigrate>
+			<ActiveCPUs>0-17</ActiveCPUs>
+			<MinPollInterval> 500 </MinPollInterval>
+			<PollIntervalIncrement> -1 </PollIntervalIncrement>
+			<MaxPollInterval> 2000 </MaxPollInterval>
+		</State>
+	</States>
 </Configuration>

--- a/data/intel_lpmd_config_examples.xml
+++ b/data/intel_lpmd_config_examples.xml
@@ -58,6 +58,13 @@ for Intel Low Power Mode daemon
 	<HfiLpmEnable>0</HfiLpmEnable>
 
 	<!--
+		Use WLT hints
+		0 : No
+		1 : Yes
+	-->
+	<WLTHintEnable>0</WLTHintEnable>
+
+	<!--
 		Use HFI SUV hints
 		0 : No
 		1 : Yes
@@ -110,7 +117,51 @@ for Intel Low Power Mode daemon
 	<IgnoreITMT>0</IgnoreITMT>
 
 	<!--
-		Example config states applied to 4Pcore-8Ecore-2Lcore 15W TDP Meteor Lake platform
+		Example WorkLoad Type hints based config states applied to
+		12Pcore-8Ecore-2Lcore 28W TDP Meteor Lake platform.
+		Need to set WLTHintEnable to make it work.
+	-->
+	<States>
+		<CPUFamily> 6 </CPUFamily>
+		<CPUModel> 170 </CPUModel>
+		<CPUConfig> 12P8E2L-28W </CPUConfig>
+		<State>
+			<ID> 1 </ID>
+			<Name> WLT_IDLE </Name>
+			<WLTType> 0 </WLTType>
+			<EPP> 255 </EPP>
+			<ITMTState> -1 </ITMTState>
+			<IRQMigrate> -1 </IRQMigrate>
+		</State>
+		<State>
+			<ID> 2 </ID>
+			<Name> WLT_BATTERY_LIFE </Name>
+			<WLTType> 1 </WLTType>
+			<EPP> 192 </EPP>
+			<ITMTState> -1 </ITMTState>
+			<IRQMigrate> -1 </IRQMigrate>
+		</State>
+		<State>
+			<ID> 3 </ID>
+			<Name> WLT_SUSTAINED </Name>
+			<WLTType> 2 </WLTType>
+			<EPP> 64 </EPP>
+			<ITMTState> -1 </ITMTState>
+			<IRQMigrate> -1 </IRQMigrate>
+		</State>
+		<State>
+			<ID> 4 </ID>
+			<Name> WLT_BURSTY </Name>
+			<WLTType> 3 </WLTType>
+			<EPP> 64 </EPP>
+			<ITMTState> -1 </ITMTState>
+			<IRQMigrate> -1 </IRQMigrate>
+		</State>
+	</States>
+
+	<!--
+		Example Utilization based config states applied to
+		4Pcore-8Ecore-2Lcore 15W TDP Meteor Lake platform.
 	-->
 	<States>
 		<CPUFamily> 6 </CPUFamily>

--- a/man/intel_lpmd_config.xml.5
+++ b/man/intel_lpmd_config.xml.5
@@ -77,6 +77,9 @@ specifies if the HFI monitor can capture the HFI hints for Low Power Mode.
 .B HfiSuvEnable
 specifies if the HFI monitor can capture the HFI hints for survivability mode.
 .PP
+.B WLTHintEnable
+Enable use of hardware Workload type hints.
+.PP
 .B util_entry_threshold
 specifies the system utilization threshold for entering Low Power Mode.
 The system workload is considered to fit the lp_mode_cpus capacity when system
@@ -116,6 +119,86 @@ If set, when the previous average time stayed out of Low-Power-Mode is lower
 than this value, the current exit Low Power Mode request will be ignored
 because it is expected that the system will enter Low Power Mode soon.
 Setting to 0 or leaving this empty disables this hysteresis algorithm.
+.PP
+.B IgnoreITMT
+Avoid changing scheduler ITMT flag. This means that during transition to
+low power mode, ITMT flag is not changed. This reduces latency during
+switching. This flag is not used when configuration uses "State" based
+configuration, where this flag can be defined per state.
+.PP
+.B States
+Allows to define per platform low power states. Each state defines
+has an entry condition and set of parameters to use.
+
+.SH State Definition
+There can be multiple State configuration can be present. Each
+configuration is valid for a platform. A State header defines parameters,
+which are used to match a platform.
+.B CPUFamily
+CPU generation to match.
+.PP
+.B CPUModel
+CPU model to match.
+.PP
+.B CPUConfig
+Define a configuration of CPUs and TDP to match different skews for the
+same CPU model and family. CPU configuration string format is:
+xPyEzL-tdpW. For example: 12P8E2L-28W, defines a platform with 6 P-cores
+with hyper threading enabled, 8 E cores, 2 LPE cores and the TDP is 28W.
+This configuration allows wildcard "*" to match any combination.
+
+.SH Per State Definition
+Each "State" defines entry criteria and parameters to use.
+.B ID
+A unique ID for the state.
+.PP
+.B Name
+A name for the state.
+.PP
+.B EntrySystemLoadThres
+System Entry load threshold in percent. System utilization is different
+based on the number of CPUs are active in a configuration. This value
+is calculated from /proc/stat sysfs. To enter into this state, the
+system utilization must be less or equal to this value.
+.PP
+.B EnterCPULoadThres
+CPU Entry load threshold in percent. Per CPU utilization is also obtained
+from /proc/stat. To enter into this state any active CPU utilization must
+be less or equal to this value.
+EnterCPULoadThres is checked before EntrySystemLoadThres to match a state.
+.PP
+.B WLTType
+Workload type value to enter into this state. If this value is defined
+then utilization based entry triggers are not used. To use this
+WLTHintEnable must be enabled, so that hardware notifications are enabled.
+.PP
+.B ActiveCPUs
+Active CPUs in this state. The list can be comma separated or use "-" for
+a range. This is optional to have active CPUs in a state.
+.PP
+.B EPP
+EPP to apply for this state. -1 to ignore.
+.PP
+.B EPB
+EPB to apply for this state. -1 to ignore.
+.PP
+.B ITMTState
+Set the state of ITMT flag. -1 to ignore.
+.PP
+.B IRQMigrate
+Migrate IRQs to the active CPUs in this state. -1 to ignore.
+.PP
+.B MinPollInterval
+Minimum polling interval in milli seconds.
+.PP
+.B MaxPollInterval
+Maximum polling interval in milli seconds. This is optional,
+if there is no maximum is desired.
+.PP
+.B PollIntervalIncrement
+Polling interval increment in milli seconds. If this value
+is -1, then polling increment is adaptive based on the utilization.
+
 
 .SH FILE FORMAT
 The configuration file format conforms to XML specifications.

--- a/man/intel_lpmd_config.xml.5
+++ b/man/intel_lpmd_config.xml.5
@@ -209,6 +209,13 @@ The configuration file format conforms to XML specifications.
 	-->
 	<ExitHystMS>Example hyst</ExitHystMS>
 
+	<!--
+		EPP to use in Low Power Mode
+		0-255: Valid EPP value to use in Low Power Mode
+		   -1: Don't change EPP in Low Power Mode
+	-->
+	<lp_mode_epp>-1 | EPP value</lp_mode_epp>
+
 </Configuration>
 
 .EE
@@ -236,6 +243,8 @@ ExitDelayMS: 0. Do not take effect when utilization monitor is disabled.
 EntryHystMS: 0. Do not take effect when utilization monitor is disabled.
 .IP \(bu 2
 ExitHystMS: 0. Do not take effect when utilization monitor is disabled.
+.IP \(bu 2
+lp_mode_epp: -1. Do not change EPP when entering Low Power Mode.
 
 .sp 1
 .EX
@@ -251,6 +260,7 @@ ExitHystMS: 0. Do not take effect when utilization monitor is disabled.
 	<ExitDelayMS>0</ExitDelayMS>
 	<EntryHystMS>0</EntryHystMS>
 	<ExitHystMS>0</ExitHystMS>
+	<lp_mode_epp>-1</lp_mode_epp>
 </Configuration>
 .PP
 .B Example 2:
@@ -275,6 +285,8 @@ ExitDelayMS: 0. Resample adaptively based on the utilization of lp_mode_cpus whe
 EntryHystMS: 2000. Ignore the current Enter Low Power Mode request when the previous average time stayed in Low Power Mode is lower than 2000ms.
 .IP \(bu 2
 ExitHystMS: 3000. Ignore the current Exit Low Power Mode request when the previous average time stayed out of Low Power Mode is lower than 3000ms.
+.IP \(bu 2
+lp_mode_epp: -1. Do not change EPP when entering Low Power Mode.
 
 .sp 1
 .EX
@@ -290,5 +302,6 @@ ExitHystMS: 3000. Ignore the current Exit Low Power Mode request when the previo
 	<ExitDelayMS>0</ExitDelayMS>
 	<EntryHystMS>2000</EntryHystMS>
 	<ExitHystMS>3000</ExitHystMS>
+	<lp_mode_epp>-1</lp_mode_epp>
 </Configuration>
 .EE

--- a/src/lpmd.h
+++ b/src/lpmd.h
@@ -156,8 +156,6 @@ enum cpumask_idx {
 	CPUMASK_HFI_LAST, CPUMASK_MAX,
 };
 
-#define MAX_LPM_CPUS		32
-
 #define UTIL_DELAY_MAX		5000
 #define UTIL_HYST_MAX		10000
 

--- a/src/lpmd.h
+++ b/src/lpmd.h
@@ -174,6 +174,10 @@ enum cpumask_idx {
 #define SETTING_RESTORE	-2
 #define SETTING_IGNORE	-1
 
+/* Helpers for entering LPMode */
+void set_lpm_epp(int val);
+int get_lpm_epp(void);
+
 /* lpmd_main.c */
 int in_debug_mode(void);
 

--- a/src/lpmd.h
+++ b/src/lpmd.h
@@ -181,6 +181,7 @@ void set_lpm_epb(int val);
 int get_lpm_epb(void);
 void set_lpm_itmt(int val);
 int get_lpm_itmt(void);
+int set_lpm_irq(cpu_set_t *cpumask, int action);
 
 /* lpmd_main.c */
 int in_debug_mode(void);
@@ -248,6 +249,11 @@ void copy_cpu_mask_exclude(enum cpumask_idx source, enum cpumask_idx dest, enum 
 void copy_cpu_mask(enum cpumask_idx source, enum cpumask_idx dest);
 void copy_cpu_mask_exclude(enum cpumask_idx source, enum cpumask_idx dest, enum cpumask_idx exlude);
 
+cpu_set_t *get_cpumask(enum cpumask_idx source);
+int cpumask_to_str(cpu_set_t *cpumask, char *buf, int size);
+int cpumask_to_hexstr(cpu_set_t *cpumask, char *buf, int size);
+int cpumask_to_str_reverse(cpu_set_t *mask, char *buf, int size);
+
 int is_equal(enum cpumask_idx idx1, enum cpumask_idx idx2);
 
 int add_cpu(int cpu, enum cpumask_idx idx);
@@ -263,6 +269,7 @@ int has_suv_support(void);
 /* irq.c */
 int init_irq(void);
 int process_irqs(int enter, enum lpm_cpu_process_mode mode);
+int update_lpm_irq(cpu_set_t *cpumask, int action);
 
 /* hfi.c */
 int hfi_init(void);

--- a/src/lpmd.h
+++ b/src/lpmd.h
@@ -177,8 +177,10 @@ void set_lpm_epp(int val);
 int get_lpm_epp(void);
 void set_lpm_epb(int val);
 int get_lpm_epb(void);
+int get_epp_epb(int *epp, char *epp_string, int size, int *epb);
 void set_lpm_itmt(int val);
 int get_lpm_itmt(void);
+int get_itmt(void);
 int set_lpm_irq(cpu_set_t *cpumask, int action);
 int set_lpm_cpus(enum cpumask_idx idx);
 

--- a/src/lpmd.h
+++ b/src/lpmd.h
@@ -35,6 +35,7 @@
 #include <string.h>
 #include <signal.h>
 #include <poll.h>
+#include <cpuid.h>
 
 #include "config.h"
 #include "thermal.h"
@@ -159,6 +160,16 @@ enum cpumask_idx {
 
 #define UTIL_DELAY_MAX		5000
 #define UTIL_HYST_MAX		10000
+
+#define cpuid(leaf, eax, ebx, ecx, edx)		\
+	__cpuid(leaf, eax, ebx, ecx, edx);	\
+	lpmd_log_debug("CPUID 0x%08x: eax = 0x%08x ebx = 0x%08x ecx = 0x%08x edx = 0x%08x\n",	\
+			leaf, eax, ebx, ecx, edx);
+
+#define cpuid_count(leaf, subleaf, eax, ebx, ecx, edx)		\
+	__cpuid_count(leaf, subleaf, eax, ebx, ecx, edx);	\
+	lpmd_log_debug("CPUID 0x%08x subleaf 0x%08x: eax = 0x%08x ebx = 0x%08x ecx = 0x%08x"	\
+			"edx = 0x%08x\n", leaf, subleaf, eax, ebx, ecx, edx);
 
 /* lpmd_main.c */
 int in_debug_mode(void);

--- a/src/lpmd.h
+++ b/src/lpmd.h
@@ -166,6 +166,8 @@ int in_debug_mode(void);
 int lpmd_lock(void);
 int lpmd_unlock(void);
 int in_lpm(void);
+int in_hfi_lpm(void);
+int in_suv_lpm(void);
 int get_idle_percentage(void);
 int get_idle_duration(void);
 int get_cpu_mode(void);
@@ -228,7 +230,6 @@ int check_cpu_hotplug(void);
 /* cpu.c : APIs for SUV mode support */
 int process_suv_mode(enum lpm_command cmd);
 int has_suv_support(void);
-int in_hfi_suv_mode(void);
 
 /* irq.c */
 int init_irq(void);

--- a/src/lpmd.h
+++ b/src/lpmd.h
@@ -154,7 +154,7 @@ enum cpumask_idx {
 	CPUMASK_MAX,
 };
 
-#define MAX_LPM_CPUS		8
+#define MAX_LPM_CPUS		32
 
 #define UTIL_DELAY_MAX		5000
 #define UTIL_HYST_MAX		10000

--- a/src/lpmd.h
+++ b/src/lpmd.h
@@ -123,6 +123,7 @@ typedef struct {
 	int util_entry_hyst;
 	int util_exit_hyst;
 	int ignore_itmt;
+	int lp_mode_epp;
 	char lp_mode_cpus[MAX_STR_LENGTH];
 } lpmd_config_t;
 

--- a/src/lpmd.h
+++ b/src/lpmd.h
@@ -151,7 +151,7 @@ enum lpm_command {
 
 enum cpumask_idx {
 	CPUMASK_LPM_DEFAULT, CPUMASK_ONLINE, CPUMASK_HFI, CPUMASK_HFI_BANNED, CPUMASK_HFI_SUV, /* HFI Survivability mode */
-	CPUMASK_MAX,
+	CPUMASK_HFI_LAST, CPUMASK_MAX,
 };
 
 #define MAX_LPM_CPUS		32
@@ -222,6 +222,10 @@ int has_lpm_cpus(void);
 int has_cpus(enum cpumask_idx idx);
 
 void copy_cpu_mask_exclude(enum cpumask_idx source, enum cpumask_idx dest, enum cpumask_idx exlude);
+void copy_cpu_mask(enum cpumask_idx source, enum cpumask_idx dest);
+void copy_cpu_mask_exclude(enum cpumask_idx source, enum cpumask_idx dest, enum cpumask_idx exlude);
+
+int is_equal(enum cpumask_idx idx1, enum cpumask_idx idx2);
 
 int add_cpu(int cpu, enum cpumask_idx idx);
 void reset_cpus(enum cpumask_idx idx);

--- a/src/lpmd.h
+++ b/src/lpmd.h
@@ -179,6 +179,8 @@ void set_lpm_epp(int val);
 int get_lpm_epp(void);
 void set_lpm_epb(int val);
 int get_lpm_epb(void);
+void set_lpm_itmt(int val);
+int get_lpm_itmt(void);
 
 /* lpmd_main.c */
 int in_debug_mode(void);

--- a/src/lpmd.h
+++ b/src/lpmd.h
@@ -107,6 +107,40 @@ typedef struct {
 } message_capsul_t;
 
 #define MAX_STR_LENGTH		256
+#define MAX_CONFIG_STATES	10
+#define MAX_STATE_NAME		16
+#define MAX_CONFIG_LEN		64
+
+typedef struct {
+	int id;
+	char name[MAX_STATE_NAME];
+	int entry_system_load_thres;
+	int exit_system_load_thres;
+	int exit_system_load_hyst;
+	int enter_cpu_load_thres;
+	int exit_cpu_load_thres;
+	int min_poll_interval;
+	int max_poll_interval;
+	int poll_interval_increment;
+	int epp;
+	int epb;
+	char active_cpus[MAX_STR_LENGTH];
+	// If active CPUs are specified then
+	// the below counts don't matter
+	int island_0_number_p_cores;
+	int island_0_number_e_cores;
+	int island_1_number_p_cores;
+	int island_1_number_e_cores;
+	int island_2_number_p_cores;
+	int island_2_number_e_cores;
+
+	int itmt_state;
+	int irq_migrate;
+
+	// Private state variables, not configurable
+	int entry_load_sys;
+	int entry_load_cpu;
+}lpmd_config_state_t;
 
 // lpmd config data
 typedef struct {
@@ -126,6 +160,11 @@ typedef struct {
 	int ignore_itmt;
 	int lp_mode_epp;
 	char lp_mode_cpus[MAX_STR_LENGTH];
+	int cpu_family;
+	int cpu_model;
+	char cpu_config[MAX_CONFIG_LEN];
+	int config_state_count;
+	lpmd_config_state_t config_states[MAX_CONFIG_STATES];
 } lpmd_config_t;
 
 enum lpm_cpu_process_mode {

--- a/src/lpmd.h
+++ b/src/lpmd.h
@@ -177,6 +177,8 @@ enum cpumask_idx {
 /* Helpers for entering LPMode */
 void set_lpm_epp(int val);
 int get_lpm_epp(void);
+void set_lpm_epb(int val);
+int get_lpm_epb(void);
 
 /* lpmd_main.c */
 int in_debug_mode(void);

--- a/src/lpmd.h
+++ b/src/lpmd.h
@@ -272,6 +272,7 @@ int lpmd_get_config(lpmd_config_t *lpmd_config);
 int periodic_util_update(void);
 
 /* cpu.c */
+int check_cpu_capability(lpmd_config_t *lpmd_config);
 int init_cpu(char *cmd_cpus, enum lpm_cpu_process_mode mode, int lp_mode_epp);
 int process_cpus(int enter, enum lpm_cpu_process_mode mode);
 

--- a/src/lpmd.h
+++ b/src/lpmd.h
@@ -150,7 +150,7 @@ enum lpm_command {
 };
 
 enum cpumask_idx {
-	CPUMASK_LPM_DEFAULT, CPUMASK_ONLINE, CPUMASK_HFI, CPUMASK_HFI_SUV, /* HFI Survivability mode */
+	CPUMASK_LPM_DEFAULT, CPUMASK_ONLINE, CPUMASK_HFI, CPUMASK_HFI_BANNED, CPUMASK_HFI_SUV, /* HFI Survivability mode */
 	CPUMASK_MAX,
 };
 
@@ -220,6 +220,8 @@ int get_max_online_cpu(void);
 char* get_lpm_cpus_hexstr(void);
 int has_lpm_cpus(void);
 int has_cpus(enum cpumask_idx idx);
+
+void copy_cpu_mask_exclude(enum cpumask_idx source, enum cpumask_idx dest, enum cpumask_idx exlude);
 
 int add_cpu(int cpu, enum cpumask_idx idx);
 void reset_cpus(enum cpumask_idx idx);

--- a/src/lpmd.h
+++ b/src/lpmd.h
@@ -113,6 +113,7 @@ typedef struct {
 
 typedef struct {
 	int id;
+	int valid;
 	char name[MAX_STATE_NAME];
 	int entry_system_load_thres;
 	int exit_system_load_thres;
@@ -192,7 +193,7 @@ enum lpm_command {
 
 enum cpumask_idx {
 	CPUMASK_LPM_DEFAULT, CPUMASK_ONLINE, CPUMASK_HFI, CPUMASK_HFI_BANNED, CPUMASK_HFI_SUV, /* HFI Survivability mode */
-	CPUMASK_HFI_LAST, CPUMASK_MAX,
+	CPUMASK_HFI_LAST, CPUMASK_UTIL, CPUMASK_MAX,
 };
 
 #define UTIL_DELAY_MAX		5000
@@ -269,12 +270,16 @@ int intel_dbus_server_init(gboolean (*exit_handler)(void));
 int lpmd_get_config(lpmd_config_t *lpmd_config);
 
 /* util.c */
-int periodic_util_update(void);
+int periodic_util_update(lpmd_config_t *lpmd_config);
+int util_init(lpmd_config_t *lpmd_config);
+int use_config_states(void);
+void reset_config_state(void);
 
 /* cpu.c */
 int check_cpu_capability(lpmd_config_t *lpmd_config);
 int init_cpu(char *cmd_cpus, enum lpm_cpu_process_mode mode, int lp_mode_epp);
 int process_cpus(int enter, enum lpm_cpu_process_mode mode);
+int parse_cpu_str(char *buf, enum cpumask_idx idx);
 
 /* cpu.c: helpers */
 int is_cpu_online(int cpu);
@@ -282,6 +287,7 @@ int is_cpu_for_lpm(int cpu);
 int get_max_cpus(void);
 int get_max_online_cpu(void);
 
+char* get_cpus_str(enum cpumask_idx idx);
 char* get_lpm_cpus_hexstr(void);
 int has_lpm_cpus(void);
 int has_cpus(enum cpumask_idx idx);

--- a/src/lpmd.h
+++ b/src/lpmd.h
@@ -182,6 +182,7 @@ int get_lpm_epb(void);
 void set_lpm_itmt(int val);
 int get_lpm_itmt(void);
 int set_lpm_irq(cpu_set_t *cpumask, int action);
+int set_lpm_cpus(enum cpumask_idx idx);
 
 /* lpmd_main.c */
 int in_debug_mode(void);

--- a/src/lpmd.h
+++ b/src/lpmd.h
@@ -115,6 +115,7 @@ typedef struct {
 	int id;
 	int valid;
 	char name[MAX_STATE_NAME];
+	int wlt_type;
 	int entry_system_load_thres;
 	int exit_system_load_thres;
 	int exit_system_load_hyst;
@@ -151,6 +152,7 @@ typedef struct {
 	int powersaver_def;
 	int hfi_lpm_enable;
 	int hfi_suv_enable;
+	int wlt_hint_enable;
 	int util_enable;
 	int util_entry_threshold;
 	int util_exit_threshold;
@@ -270,7 +272,7 @@ int intel_dbus_server_init(gboolean (*exit_handler)(void));
 int lpmd_get_config(lpmd_config_t *lpmd_config);
 
 /* util.c */
-int periodic_util_update(lpmd_config_t *lpmd_config);
+int periodic_util_update(lpmd_config_t *lpmd_config, int wlt_index);
 int util_init(lpmd_config_t *lpmd_config);
 int use_config_states(void);
 void reset_config_state(void);

--- a/src/lpmd.h
+++ b/src/lpmd.h
@@ -209,7 +209,7 @@ int lpmd_get_config(lpmd_config_t *lpmd_config);
 int periodic_util_update(void);
 
 /* cpu.c */
-int init_cpu(char *cmd_cpus, enum lpm_cpu_process_mode mode);
+int init_cpu(char *cmd_cpus, enum lpm_cpu_process_mode mode, int lp_mode_epp);
 int process_cpus(int enter, enum lpm_cpu_process_mode mode);
 
 /* cpu.c: helpers */

--- a/src/lpmd.h
+++ b/src/lpmd.h
@@ -171,6 +171,9 @@ enum cpumask_idx {
 	lpmd_log_debug("CPUID 0x%08x subleaf 0x%08x: eax = 0x%08x ebx = 0x%08x ecx = 0x%08x"	\
 			"edx = 0x%08x\n", leaf, subleaf, eax, ebx, ecx, edx);
 
+#define SETTING_RESTORE	-2
+#define SETTING_IGNORE	-1
+
 /* lpmd_main.c */
 int in_debug_mode(void);
 

--- a/src/lpmd_config.c
+++ b/src/lpmd_config.c
@@ -36,6 +36,7 @@ static void lpmd_dump_config(lpmd_config_t *lpmd_config)
 	lpmd_log_info ("Util entry threshold:%d\n", lpmd_config->util_entry_threshold);
 	lpmd_log_info ("Util exit threshold:%d\n", lpmd_config->util_exit_threshold);
 	lpmd_log_info ("Util LP Mode CPUs:%s\n", lpmd_config->lp_mode_cpus);
+	lpmd_log_info ("EPP in LP Mode:%d\n", lpmd_config->lp_mode_epp);
 }
 
 static int lpmd_fill_config(xmlDoc *doc, xmlNode *a_node, lpmd_config_t *lpmd_config)
@@ -48,6 +49,7 @@ static int lpmd_fill_config(xmlDoc *doc, xmlNode *a_node, lpmd_config_t *lpmd_co
 		return LPMD_ERROR;
 
 	lpmd_config->performance_def = lpmd_config->balanced_def = lpmd_config->powersaver_def = LPM_FORCE_OFF;
+	lpmd_config->lp_mode_epp = -1;
 	for (cur_node = a_node; cur_node; cur_node = cur_node->next) {
 		if (cur_node->type == XML_ELEMENT_NODE) {
 			tmp_value = (char*) xmlNodeListGetString (doc, cur_node->xmlChildrenNode, 1);
@@ -125,6 +127,16 @@ static int lpmd_fill_config(xmlDoc *doc, xmlNode *a_node, lpmd_config_t *lpmd_co
 							|| *pos
 									!= '\0'|| lpmd_config->util_exit_hyst < 0 || lpmd_config->util_exit_hyst > UTIL_HYST_MAX)
 						goto err;
+				}
+				else if (!strncmp((const char*)cur_node->name, "lp_mode_epp", strlen ("lp_mode_epp"))) {
+					errno = 0;
+					lpmd_config->lp_mode_epp = strtol (tmp_value, &pos, 10);
+					if (errno
+							|| *pos
+									!= '\0'|| lpmd_config->lp_mode_epp > 255 || lpmd_config->lp_mode_epp < -1)
+						goto err;
+					if (lpmd_config->lp_mode_epp < 0)
+						lpmd_config->lp_mode_epp = -1;
 				}
 				else if (!strncmp((const char*)cur_node->name, "IgnoreITMT", strlen ("IgnoreITMT"))) {
 					errno = 0;

--- a/src/lpmd_config.c
+++ b/src/lpmd_config.c
@@ -148,6 +148,8 @@ static void lpmd_parse_states(xmlDoc *doc, xmlNode *a_node, lpmd_config_t *lpmd_
 	char *tmp_value;
 	char *pos;
 	int config_state_count = 0;
+	int cpu_family = -1, cpu_model = -1;
+	char cpu_config[MAX_CONFIG_LEN];
 
 	if (!doc || !a_node || !lpmd_config)
 		return;
@@ -156,24 +158,33 @@ static void lpmd_parse_states(xmlDoc *doc, xmlNode *a_node, lpmd_config_t *lpmd_
 	if (lpmd_config->config_state_count)
 		return;
 
+	cpu_config[0] = '\0';
+
 	for (cur_node = a_node; cur_node; cur_node = cur_node->next) {
 		if (cur_node->type == XML_ELEMENT_NODE) {
 			if (cur_node->name) {
+
 				tmp_value = (char*) xmlNodeListGetString (doc, cur_node->xmlChildrenNode, 1);
 
 				if (!strncmp ((const char*) cur_node->name, "CPUFamily", strlen ("CPUFamily")))
-					lpmd_config->cpu_family = strtol (tmp_value, &pos, 10);
+					cpu_family = strtol (tmp_value, &pos, 10);
 
 				if (!strncmp ((const char*) cur_node->name, "CPUModel", strlen ("CPUModel")))
-					lpmd_config->cpu_model = strtol (tmp_value, &pos, 10);
+					cpu_model = strtol (tmp_value, &pos, 10);
 
 				if (!strncmp ((const char*) cur_node->name, "CPUConfig", strlen ("CPUConfig"))) {
-					snprintf (lpmd_config->cpu_config, MAX_CONFIG_LEN - 1, "%s", tmp_value);
-					lpmd_config->cpu_config[MAX_CONFIG_LEN - 1] = '\0';
+					snprintf (cpu_config, MAX_CONFIG_LEN - 1, "%s", tmp_value);
+					cpu_config[MAX_CONFIG_LEN - 1] = '\0';
 				}
 
 				if (strncmp ((const char*) cur_node->name, "State", strlen ("State")))
 					continue;
+
+				/* Must check cpu family/model/config first to make sure the states applies */
+				if (cpu_family != lpmd_config->cpu_family || cpu_model != lpmd_config->cpu_model || (strncmp(cpu_config, lpmd_config->cpu_config, MAX_CONFIG_LEN) && strncmp(cpu_config, " * ", strlen(" * ")))) {
+					lpmd_log_info("Ignore unsupported states for CPU family:%d,model%d,config:%s\n", cpu_family, cpu_model, cpu_config);
+					return;
+				}
 
 				if (lpmd_config->config_state_count >= MAX_CONFIG_STATES)
 					break;

--- a/src/lpmd_config.c
+++ b/src/lpmd_config.c
@@ -148,6 +148,19 @@ static void lpmd_parse_state(xmlDoc *doc, xmlNode *a_node, lpmd_config_state_t *
 	}
 }
 
+static int validate_config_state(lpmd_config_t *lpmd_config, lpmd_config_state_t *state)
+{
+	if (lpmd_config->wlt_hint_enable) {
+		if (state->wlt_type >=0 && state->wlt_type <= 3)
+			state->valid = 1;
+	} else {
+		if ((state->enter_cpu_load_thres > 0 && state->enter_cpu_load_thres <= 100) ||
+		    (state->entry_system_load_thres > 0 && state->entry_system_load_thres <= 100))
+			state->valid = 1;
+	}
+	return 0;
+}
+
 static void lpmd_parse_states(xmlDoc *doc, xmlNode *a_node, lpmd_config_t *lpmd_config)
 {
 	xmlNode *cur_node = NULL;
@@ -195,7 +208,8 @@ static void lpmd_parse_states(xmlDoc *doc, xmlNode *a_node, lpmd_config_t *lpmd_
 				if (lpmd_config->config_state_count >= MAX_CONFIG_STATES)
 					break;
 				lpmd_parse_state (doc, cur_node->children, &lpmd_config->config_states[config_state_count]);
-				config_state_count++;
+				validate_config_state(lpmd_config, &lpmd_config->config_states[config_state_count]);
+				config_state_count += lpmd_config->config_states[config_state_count].valid;
 			}
 		}
 	}

--- a/src/lpmd_cpu.c
+++ b/src/lpmd_cpu.c
@@ -377,6 +377,9 @@ int add_cpu(int cpu, enum cpumask_idx idx)
 
 	_add_cpu (cpu, idx);
 
+	if (idx & (CPUMASK_HFI | CPUMASK_HFI_SUV | CPUMASK_HFI_BANNED))
+		return 0;
+
 	if (idx == CPUMASK_LPM_DEFAULT)
 		lpmd_log_info ("\tDetected %s CPU%d\n", cpumasks[idx].name, cpu);
 	else

--- a/src/lpmd_cpu.c
+++ b/src/lpmd_cpu.c
@@ -69,7 +69,9 @@ static struct lpm_cpus cpumasks[CPUMASK_MAX] = {
 		[CPUMASK_LPM_DEFAULT] = { .name = "Low Power", },
 		[CPUMASK_ONLINE] = { .name = "Online", },
 		[CPUMASK_HFI] = { .name = "HFI Low Power", },
+		[CPUMASK_HFI_BANNED] = { .name = "HFI BANNED", },
 		[CPUMASK_HFI_SUV] = { .name = "HFI SUV", },
+		[CPUMASK_HFI_LAST] = { .name = "HFI LAST", },
 };
 
 static enum cpumask_idx lpm_cpus_cur = CPUMASK_LPM_DEFAULT;
@@ -330,6 +332,17 @@ set_val: if (j == 7) {
 	return 0;
 }
 
+int is_equal(enum cpumask_idx idx1, enum cpumask_idx idx2)
+{
+	if (!cpumasks[idx1].mask || !cpumasks[idx2].mask)
+		return 0;
+
+	if (CPU_EQUAL_S(size_cpumask, cpumasks[idx1].mask, cpumasks[idx2].mask))
+		return 1;
+
+	return 0;
+}
+
 int has_cpus(enum cpumask_idx idx)
 {
 	if (!cpumasks[idx].mask)
@@ -386,6 +399,18 @@ void reset_cpus(enum cpumask_idx idx)
 	cpumasks[idx].hexstr = NULL;
 	cpumasks[idx].hexstr_reverse = NULL;
 	lpm_cpus_cur = CPUMASK_LPM_DEFAULT;
+}
+
+void copy_cpu_mask(enum cpumask_idx source, enum cpumask_idx dest)
+{
+	int i;
+
+	for (i = 0; i < topo_max_cpus; i++) {
+		if (!CPU_ISSET_S(i, size_cpumask, cpumasks[source].mask))
+			continue;
+
+		_add_cpu(i, dest);
+	}
 }
 
 void copy_cpu_mask_exclude(enum cpumask_idx source, enum cpumask_idx dest, enum cpumask_idx exlude)

--- a/src/lpmd_cpu.c
+++ b/src/lpmd_cpu.c
@@ -591,6 +591,27 @@ int set_epp(char *path, int val, char *str)
 	return !(ret > 0);
 }
 
+int get_epp_epb(int *epp, char *epp_str, int size, int *epb)
+{
+	int c;
+	char path[MAX_STR_LENGTH];
+
+	for (c = 0; c < max_online_cpu; c++) {
+		if (!is_cpu_online (c))
+			continue;
+
+		*epp = -1;
+		epp_str[0] = '\0';
+		snprintf (path, sizeof(path), "/sys/devices/system/cpu/cpu%d/cpufreq/energy_performance_preference", c);
+		get_epp (path, epp, epp_str, size);
+
+		snprintf(path, MAX_STR_LENGTH, "/sys/devices/system/cpu/cpu%d/power/energy_perf_bias", c);
+		lpmd_read_int(path, epb, -1);
+		return 0;
+	}
+	return 1;
+}
+
 int init_epp_epb(void)
 {
 	int max_cpus = get_max_cpus ();

--- a/src/lpmd_cpu.c
+++ b/src/lpmd_cpu.c
@@ -387,9 +387,6 @@ static int _add_cpu(int cpu, enum cpumask_idx idx)
 	if (!cpumasks[idx].mask)
 		alloc_cpu_set (&cpumasks[idx].mask);
 
-	if (idx != CPUMASK_ONLINE && CPU_COUNT_S(size_cpumask, cpumasks[idx].mask) >= MAX_LPM_CPUS)
-		return LPMD_FATAL_ERROR;
-
 	CPU_SET_S(cpu, size_cpumask, cpumasks[idx].mask);
 
 	return LPMD_SUCCESS;

--- a/src/lpmd_cpu.c
+++ b/src/lpmd_cpu.c
@@ -212,7 +212,7 @@ int cpumask_to_hexstr(cpu_set_t *mask, char *str, int size)
 	return 0;
 }
 
-static char* get_cpus_str(enum cpumask_idx idx)
+char* get_cpus_str(enum cpumask_idx idx)
 {
 	if (!cpumasks[idx].mask)
 		return NULL;
@@ -934,7 +934,7 @@ static void lpmd_set_cpu_affinity(void)
  * parse cpuset with following syntax
  * 1,2,4..6,8-10 and set bits in cpu_subset
  */
-static int parse_cpu_str(char *buf, enum cpumask_idx idx)
+int parse_cpu_str(char *buf, enum cpumask_idx idx)
 {
 	unsigned int start, end;
 	char *next;

--- a/src/lpmd_cpu.c
+++ b/src/lpmd_cpu.c
@@ -472,6 +472,141 @@ static int set_max_cpu_num(void)
 	return 0;
 }
 
+/* Handling EPP */
+static int lp_mode_epp;
+
+struct cpu_epp {
+	char str[32];
+	int val;
+};
+static struct cpu_epp *cpu_saved_epp;
+
+int get_epp(int cpu, int *val, char *str, int size)
+{
+	FILE *filep;
+	char path[MAX_STR_LENGTH];
+	int epp;
+	int ret;
+
+	snprintf (path, sizeof(path), "/sys/devices/system/cpu/cpu%d/cpufreq/energy_performance_preference", cpu);
+
+	filep = fopen (path, "r");
+	if (!filep)
+		return 1;
+
+	ret = fscanf (filep, "%d", &epp);
+	if (ret == 1) {
+		*val = epp;
+		ret = 0;
+		goto end;
+	}
+
+	ret = fread (str, 1, size, filep);
+	if (ret <= 0)
+		ret = 1;
+	else {
+		if (ret >= size)
+			ret = size - 1;
+		str[ret - 1] = '\0';
+		ret = 0;
+	}
+end:
+	fclose (filep);
+	return ret;
+}
+
+int set_epp(int cpu, int val, char *str)
+{
+	FILE *filep;
+	char path[MAX_STR_LENGTH];
+	int epp;
+	int ret;
+
+	snprintf (path, sizeof(path), "/sys/devices/system/cpu/cpu%d/cpufreq/energy_performance_preference", cpu);
+
+	filep = fopen (path, "r+");
+	if (!filep)
+		return 1;
+
+	if (val >= 0)
+		ret = fprintf (filep, "%d", val);
+	else if (str)
+		ret = fprintf (filep, "%s", str);
+	else {
+		fclose (filep);
+		return 1;
+	}
+
+	fclose (filep);
+
+	if (ret <= 0) {
+		if (val >= 0)
+			lpmd_log_error ("Write \"%d\" to %s failed, ret %d\n", val, path, ret);
+		else
+			lpmd_log_error ("Write \"%s\" to %s failed, ret %d\n", str, path, ret);
+	}
+	return !(ret > 0);
+}
+
+int init_epp(int epp)
+{
+	int max_cpus = get_max_cpus ();
+	int c;
+	int ret;
+
+	lp_mode_epp = epp;
+
+	if (lp_mode_epp < 0)
+		return 0;
+
+	cpu_saved_epp = malloc (sizeof(struct cpu_epp) * max_cpus);
+
+	for (c = 0; c < max_cpus; c++) {
+		cpu_saved_epp[c].str[0] = '\0';
+		cpu_saved_epp[c].val = -1;
+
+		if (!is_cpu_online (c))
+			continue;
+		ret = get_epp (c, &cpu_saved_epp[c].val, cpu_saved_epp[c].str, 32);
+		if (ret)
+			continue;
+		if (cpu_saved_epp[c].val != -1)
+			lpmd_log_debug("CPU%d EPP: 0x%x\n", c, cpu_saved_epp[c].val);
+		else
+			lpmd_log_debug("CPU%d EPP: %s\n", c, cpu_saved_epp[c].str);
+	}
+	lpmd_log_debug("Use EPP 0x%x in Low Power Mode\n", lp_mode_epp);
+	return 0;
+}
+
+int process_epp(int enter)
+{
+	int max_cpus = get_max_cpus ();
+	int c;
+	int ret;
+
+	if (lp_mode_epp < 0)
+		return 0;
+
+	for (c = 0; c < max_cpus; c++) {
+		int val;
+
+		if (!is_cpu_online (c))
+			continue;
+
+		val = enter ? lp_mode_epp : cpu_saved_epp[c].val;
+		ret = set_epp (c, val, cpu_saved_epp[c].str);
+
+		if (!ret) {
+			if (val != -1)
+				lpmd_log_debug ("Set CPU%d EPP to 0x%x\n", c, val);
+			else
+				lpmd_log_debug ("Set CPU%d EPP to %s\n", c, cpu_saved_epp[c].str);
+		}
+	}
+	return 0;
+}
+
 static int uevent_fd = -1;
 
 int uevent_init(void)
@@ -1544,7 +1679,7 @@ static int check_cpu_mode_support(enum lpm_cpu_process_mode mode)
 	return ret;
 }
 
-int init_cpu(char *cmd_cpus, enum lpm_cpu_process_mode mode)
+int init_cpu(char *cmd_cpus, enum lpm_cpu_process_mode mode, int epp)
 {
 	int ret;
 
@@ -1561,6 +1696,7 @@ int init_cpu(char *cmd_cpus, enum lpm_cpu_process_mode mode)
 	if (ret)
 		return ret;
 
+	init_epp (epp);
 	return 0;
 }
 
@@ -1570,6 +1706,8 @@ int process_cpus(int enter, enum lpm_cpu_process_mode mode)
 
 	if (enter != 1 && enter != 0)
 		return LPMD_ERROR;
+
+	process_epp (enter);
 
 	lpmd_log_info ("Process CPUs ...\n");
 	switch (mode) {

--- a/src/lpmd_cpu.c
+++ b/src/lpmd_cpu.c
@@ -146,11 +146,12 @@ static int cpu_migrate(int cpu)
 		return 0;
 }
 
-static int cpumask_to_str(cpu_set_t *mask, char *buf, int length)
+int cpumask_to_str(cpu_set_t *mask, char *buf, int length)
 {
 	int i;
 	int offset = 0;
 
+	buf[0] = '\0';
 	for (i = 0; i < topo_max_cpus; i++) {
 		if (!CPU_ISSET_S(i, size_cpumask, mask))
 			continue;
@@ -173,7 +174,7 @@ static char to_hexchar(int val)
 	return val - 10 + 'a';
 }
 
-static int cpumask_to_hexstr(cpu_set_t *mask, char *str, int size)
+int cpumask_to_hexstr(cpu_set_t *mask, char *str, int size)
 {
 	int cpu;
 	int i;
@@ -276,6 +277,18 @@ static char* get_cpus_hexstr_reverse(enum cpumask_idx idx)
 	return cpumasks[idx].hexstr_reverse;
 }
 
+int cpumask_to_str_reverse(cpu_set_t *mask, char *buf, int size)
+{
+	cpu_set_t *tmp;
+
+	alloc_cpu_set (&tmp);
+	CPU_XOR_S(size_cpumask, tmp, mask, cpumasks[CPUMASK_ONLINE].mask);
+	cpumask_to_str (tmp, buf, size);
+	CPU_FREE(tmp);
+
+	return 0;
+}
+
 static char* get_cpus_str_reverse(enum cpumask_idx idx)
 {
 	cpu_set_t *mask;
@@ -352,6 +365,11 @@ int has_cpus(enum cpumask_idx idx)
 int has_lpm_cpus(void)
 {
 	return has_cpus (lpm_cpus_cur);
+}
+
+cpu_set_t *get_cpumask(enum cpumask_idx idx)
+{
+	return cpumasks[idx].mask;
 }
 
 static int _add_cpu(int cpu, enum cpumask_idx idx)

--- a/src/lpmd_cpu.c
+++ b/src/lpmd_cpu.c
@@ -40,7 +40,6 @@
 #include <sys/un.h>
 #include <errno.h>
 #include <getopt.h>
-#include <cpuid.h>
 #include <sched.h>
 #include <dirent.h>
 #include <ctype.h>
@@ -760,16 +759,6 @@ static struct cpu_model_entry id_table[] = {
 		{ 6, 0xac }, // Meteorlake
 		{ 0, 0 } // Last Invalid entry
 };
-
-#define cpuid(leaf, eax, ebx, ecx, edx)		\
-	__cpuid(leaf, eax, ebx, ecx, edx);	\
-	lpmd_log_debug("CPUID 0x%08x: eax = 0x%08x ebx = 0x%08x ecx = 0x%08x edx = 0x%08x\n",	\
-			leaf, eax, ebx, ecx, edx);
-
-#define cpuid_count(leaf, subleaf, eax, ebx, ecx, edx)		\
-	__cpuid_count(leaf, subleaf, eax, ebx, ecx, edx);	\
-	lpmd_log_debug("CPUID 0x%08x subleaf 0x%08x: eax = 0x%08x ebx = 0x%08x ecx = 0x%08x"	\
-			"edx = 0x%08x\n", leaf, subleaf, eax, ebx, ecx, edx);
 
 static int detect_supported_cpu(void)
 {

--- a/src/lpmd_cpu.c
+++ b/src/lpmd_cpu.c
@@ -480,6 +480,7 @@ static int set_max_cpu_num(void)
 struct cpu_info {
 	char epp_str[MAX_EPP_STRING_LENGTH];
 	int epp;
+	int epb;
 };
 static struct cpu_info *saved_cpu_info;
 
@@ -495,14 +496,23 @@ void set_lpm_epp(int val)
 	lp_mode_epp = val;
 }
 
-int get_epp(int cpu, int *val, char *str, int size)
+static int lp_mode_epb = SETTING_IGNORE;
+
+int get_lpm_epb(void)
+{
+	return lp_mode_epb;
+}
+
+void set_lpm_epb(int val)
+{
+	lp_mode_epb = val;
+}
+
+int get_epp(char *path, int *val, char *str, int size)
 {
 	FILE *filep;
-	char path[MAX_STR_LENGTH];
 	int epp;
 	int ret;
-
-	snprintf (path, sizeof(path), "/sys/devices/system/cpu/cpu%d/cpufreq/energy_performance_preference", cpu);
 
 	filep = fopen (path, "r");
 	if (!filep)
@@ -529,14 +539,11 @@ end:
 	return ret;
 }
 
-int set_epp(int cpu, int val, char *str)
+int set_epp(char *path, int val, char *str)
 {
 	FILE *filep;
-	char path[MAX_STR_LENGTH];
 	int epp;
 	int ret;
-
-	snprintf (path, sizeof(path), "/sys/devices/system/cpu/cpu%d/cpufreq/energy_performance_preference", cpu);
 
 	filep = fopen (path, "r+");
 	if (!filep)
@@ -562,11 +569,12 @@ int set_epp(int cpu, int val, char *str)
 	return !(ret > 0);
 }
 
-int init_epp(int epp)
+int init_epp_epb(void)
 {
 	int max_cpus = get_max_cpus ();
 	int c;
 	int ret;
+	char path[MAX_STR_LENGTH];
 
 	saved_cpu_info = malloc (sizeof(struct cpu_info) * max_cpus);
 
@@ -577,28 +585,39 @@ int init_epp(int epp)
 		if (!is_cpu_online (c))
 			continue;
 
-		ret = get_epp (c, &saved_cpu_info[c].epp, saved_cpu_info[c].epp_str, MAX_EPP_STRING_LENGTH);
-		if (ret)
-			continue;
+		snprintf (path, sizeof(path), "/sys/devices/system/cpu/cpu%d/cpufreq/energy_performance_preference", c);
+		ret = get_epp (path, &saved_cpu_info[c].epp, saved_cpu_info[c].epp_str, MAX_EPP_STRING_LENGTH);
+		if (!ret) {
+			if (saved_cpu_info[c].epp != -1)
+				lpmd_log_debug ("CPU%d EPP: 0x%x\n", c, saved_cpu_info[c].epp);
+			else
+				lpmd_log_debug ("CPU%d EPP: %s\n", c, saved_cpu_info[c].epp_str);
+		}
 
-		if (saved_cpu_info[c].epp != -1)
-			lpmd_log_debug ("CPU%d EPP: 0x%x\n", c, saved_cpu_info[c].epp);
-		else
-			lpmd_log_debug ("CPU%d EPP: %s\n", c, saved_cpu_info[c].epp_str);
+		snprintf(path, MAX_STR_LENGTH, "/sys/devices/system/cpu/cpu%d/power/energy_perf_bias", c);
+		ret = lpmd_read_int(path, &saved_cpu_info[c].epb, -1);
+		if (ret) {
+			saved_cpu_info[c].epb = -1;
+			continue;
+		}
+		lpmd_log_debug ("CPU%d EPB: 0x%x\n", c, saved_cpu_info[c].epb);
 	}
 	return 0;
 }
 
-int process_epp(int enter)
+int process_epp_epb(void)
 {
 	int max_cpus = get_max_cpus ();
 	int c;
 	int ret;
+	char path[MAX_STR_LENGTH];
 
-	if (lp_mode_epp == SETTING_IGNORE) {
+	if (lp_mode_epp == SETTING_IGNORE)
 		lpmd_log_debug ("Ignore EPP\n");
+	if (lp_mode_epb == SETTING_IGNORE)
+		lpmd_log_debug ("Ignore EPB\n");
+	if (lp_mode_epp == SETTING_IGNORE && lp_mode_epb == SETTING_IGNORE)
 		return 0;
-	}
 
 	for (c = 0; c < max_cpus; c++) {
 		int val;
@@ -606,19 +625,33 @@ int process_epp(int enter)
 		if (!is_cpu_online (c))
 			continue;
 
-		if (lp_mode_epp == SETTING_RESTORE)
-			val = saved_cpu_info[c].epp;
-		else
-			val = lp_mode_epp;
+		if (lp_mode_epp != SETTING_IGNORE) {
+			if (lp_mode_epp == SETTING_RESTORE)
+				val = saved_cpu_info[c].epp;
+			else
+				val = lp_mode_epp;
 
-		ret = set_epp (c, val, saved_cpu_info[c].epp_str);
-		if (ret)
-			continue;
+			snprintf (path, sizeof(path), "/sys/devices/system/cpu/cpu%d/cpufreq/energy_performance_preference", c);
+			ret = set_epp (path, val, saved_cpu_info[c].epp_str);
+			if (!ret) {
+				if (val != -1)
+					lpmd_log_debug ("Set CPU%d EPP to 0x%x\n", c, val);
+				else
+					lpmd_log_debug ("Set CPU%d EPP to %s\n", c, saved_cpu_info[c].epp_str);
+			}
+		}
 
-		if (val != -1)
-			lpmd_log_debug ("Set CPU%d EPP to 0x%x\n", c, val);
-		else
-			lpmd_log_debug ("Set CPU%d EPP to %s\n", c, saved_cpu_info[c].epp_str);
+		if (lp_mode_epb != SETTING_IGNORE) {
+			if (lp_mode_epb == SETTING_RESTORE)
+				val = saved_cpu_info[c].epb;
+			else
+				val = lp_mode_epb;
+
+			snprintf (path, MAX_STR_LENGTH, "/sys/devices/system/cpu/cpu%d/power/energy_perf_bias", c);
+			ret = lpmd_write_int(path, val, -1);
+			if (!ret)
+				lpmd_log_debug ("Set CPU%d EPB to 0x%x\n", c, val);
+		}
 	}
 	return 0;
 }
@@ -1702,7 +1735,7 @@ int init_cpu(char *cmd_cpus, enum lpm_cpu_process_mode mode, int epp)
 	if (ret)
 		return ret;
 
-	init_epp (epp);
+	init_epp_epb ();
 	return 0;
 }
 
@@ -1713,7 +1746,7 @@ int process_cpus(int enter, enum lpm_cpu_process_mode mode)
 	if (enter != 1 && enter != 0)
 		return LPMD_ERROR;
 
-	process_epp (enter);
+	process_epp_epb ();
 
 	lpmd_log_info ("Process CPUs ...\n");
 	switch (mode) {

--- a/src/lpmd_cpu.c
+++ b/src/lpmd_cpu.c
@@ -853,7 +853,7 @@ static struct cpu_model_entry id_table[] = {
 		{ 0, 0 } // Last Invalid entry
 };
 
-static int detect_supported_cpu(void)
+static int detect_supported_cpu(lpmd_config_t *lpmd_config)
 {
 	unsigned int eax, ebx, ecx, edx;
 	unsigned int max_level, family, model, stepping;
@@ -891,6 +891,9 @@ static int detect_supported_cpu(void)
 		return -1;
         }
 
+	lpmd_config->cpu_family = family;
+	lpmd_config->cpu_model = model;
+
 	cpuid_count(7, 0, eax, ebx, ecx, edx);
 
 	/* Run on Hybrid platforms only */
@@ -909,49 +912,6 @@ static int detect_supported_cpu(void)
 		lpmd_log_debug("Non Mobile platform detected\n");
 		return -1;
 	}
-
-	return 0;
-}
-
-static int parse_cpu_topology(void)
-{
-	FILE *filep;
-	int i;
-	char path[MAX_STR_LENGTH];
-	int ret;
-
-	ret = detect_supported_cpu();
-	if (ret) {
-		lpmd_log_info("Unsupported CPU type\n");
-		return ret;
-	}
-
-	ret = set_max_cpu_num ();
-	if (ret)
-		return ret;
-
-	reset_cpus (CPUMASK_ONLINE);
-	for (i = 0; i < topo_max_cpus; i++) {
-		unsigned int online = 0;
-
-		snprintf (path, sizeof(path), "/sys/devices/system/cpu/cpu%d/online", i);
-		filep = fopen (path, "r");
-		if (filep) {
-			if (fscanf (filep, "%u", &online) != 1)
-				lpmd_log_warn ("fread failed for %s\n", path);
-			fclose (filep);
-		}
-		else if (!i)
-			online = 1;
-		else
-			break;
-
-		if (!online)
-			continue;
-
-		add_cpu (i, CPUMASK_ONLINE);
-	}
-	max_online_cpu = i;
 
 	return 0;
 }
@@ -1076,6 +1036,57 @@ static int is_cpu_atom(int cpu)
 	return type == 0x20;
 }
 
+static int is_cpu_in_l3(int cpu)
+{
+	unsigned int eax, ebx, ecx, edx, subleaf;
+
+	if (cpu_migrate(cpu) < 0) {
+		lpmd_log_error("Failed to migrated to cpu%d\n", cpu);
+		err (1, "cpu migrate");
+	}
+
+	for(subleaf = 0;; subleaf++) {
+		unsigned int type, level;
+
+		cpuid_count(4, subleaf, eax, ebx, ecx, edx);
+
+		type = eax & 0x1f;
+		level = (eax >> 5) & 0x7;
+
+		/* No more caches */
+		if (!type)
+			break;
+		/* Unified Cache */
+		if (type !=3 )
+			continue;
+		/* L3 */
+		if (level != 3)
+			continue;
+
+		return 1;
+	}
+	return 0;
+}
+
+static int is_cpu_pcore(int cpu)
+{
+	return !is_cpu_atom(cpu);
+}
+
+static int is_cpu_ecore(int cpu)
+{
+	if (!is_cpu_atom(cpu))
+		return 0;
+	return is_cpu_in_l3(cpu);
+}
+
+static int is_cpu_lcore(int cpu)
+{
+	if (!is_cpu_atom(cpu))
+		return 0;
+	return !is_cpu_in_l3(cpu);
+}
+
 static int detect_lpm_cpus_cluster(void)
 {
 	FILE *filep;
@@ -1121,54 +1132,25 @@ static int detect_lpm_cpus_cluster(void)
 	return CPU_COUNT_S(size_cpumask, cpumasks[CPUMASK_LPM_DEFAULT].mask);
 }
 
-static int detect_cpu_l3(int cpu)
+static int detect_cpu_lcore(int cpu)
 {
-	unsigned int eax, ebx, ecx, edx, subleaf;
-
-	if (cpu_migrate(cpu) < 0) {
-		lpmd_log_error("Failed to migrated to cpu%d\n", cpu);
-		return -1;
-	}
-
-	for(subleaf = 0;; subleaf++) {
-		unsigned int type, level;
-
-		cpuid_count(4, subleaf, eax, ebx, ecx, edx);
-
-		type = eax & 0x1f;
-		level = (eax >> 5) & 0x7;
-
-		/* No more caches */
-		if (!type)
-			break;
-		/* Unified Cache */
-		if (type !=3 )
-			continue;
-		/* L3 */
-		if (level != 3)
-			continue;
-
-		/* Do nothing about CPUs that have L3 */
-		return 0;
-	}
-
-	/* Use CPUs don't have L3 as LPM CPUs */
-	_add_cpu (cpu, CPUMASK_LPM_DEFAULT);
+	if (is_cpu_lcore(cpu))
+		_add_cpu (cpu, CPUMASK_LPM_DEFAULT);
 	return 0;
 }
 
 /*
- * Use CPUs that don't have L3 as LPM CPUs.
+ * Use Lcore CPUs as LPM CPUs.
  * Applies on platforms like MeteorLake.
  */
-static int detect_lpm_cpus_l3(void)
+static int detect_lpm_cpus_lcore(void)
 {
 	int i;
 
 	for (i = 0; i < topo_max_cpus; i++) {
 		if (!is_cpu_online (i))
 			continue;
-		if (detect_cpu_l3(i) < 0)
+		if (detect_cpu_lcore(i) < 0)
 			return -1;
 	}
 
@@ -1202,7 +1184,7 @@ static int detect_lpm_cpus(char *cmd_cpus)
 		goto end;
 	}
 
-	ret = detect_lpm_cpus_l3 ();
+	ret = detect_lpm_cpus_lcore ();
 	if (ret < 0)
 		return ret;
 
@@ -1767,14 +1749,129 @@ static int check_cpu_mode_support(enum lpm_cpu_process_mode mode)
 	return ret;
 }
 
+#define PATH_RAPL	"/sys/class/powercap"
+static int get_tdp(void)
+{
+	FILE *filep;
+	DIR *dir;
+	struct dirent *entry;
+	int ret;
+	char path[MAX_STR_LENGTH];
+	char str[MAX_STR_LENGTH];
+	char *pos;
+	int tdp = 0;
+
+
+	if ((dir = opendir (PATH_RAPL)) == NULL) {
+		perror ("opendir() error");
+		return 1;
+	}
+
+	while ((entry = readdir (dir)) != NULL) {
+		if (strlen (entry->d_name) > 100)
+			continue;
+
+		if (strncmp(entry->d_name, "intel-rapl", strlen("intel-rapl")))
+			continue;
+
+		snprintf (path, MAX_STR_LENGTH, "%s/%s/name", PATH_RAPL, entry->d_name);
+		filep = fopen (path, "r");
+		if (!filep)
+			continue;
+
+		ret = fread (str, 1, MAX_STR_LENGTH, filep);
+		fclose (filep);
+
+		if (ret <= 0)
+			continue;
+
+		if (strncmp(str, "package", strlen("package")))
+			continue;
+
+		snprintf (path, MAX_STR_LENGTH, "%s/%s/constraint_0_max_power_uw", PATH_RAPL, entry->d_name);
+		filep = fopen (path, "r");
+		if (!filep)
+			continue;
+
+		ret = fread (str, 1, MAX_STR_LENGTH, filep);
+		fclose (filep);
+
+		if (ret <= 0)
+			continue;
+
+		if (ret >= MAX_STR_LENGTH)
+			ret = MAX_STR_LENGTH - 1;
+
+		str[ret] = '\0';
+		tdp = strtol(str, &pos, 10);
+		break;
+	}
+	closedir (dir);
+
+	return tdp / 1000000;
+}
+
+int check_cpu_capability(lpmd_config_t *lpmd_config)
+{
+	FILE *filep;
+	int i;
+	char path[MAX_STR_LENGTH];
+	int ret;
+	int pcores, ecores, lcores;
+	int tdp;
+
+	ret = detect_supported_cpu(lpmd_config);
+	if (ret) {
+		lpmd_log_info("Unsupported CPU type\n");
+		return ret;
+	}
+
+	ret = set_max_cpu_num ();
+	if (ret)
+		return ret;
+
+	reset_cpus (CPUMASK_ONLINE);
+	pcores = ecores = lcores = 0;
+
+	for (i = 0; i < topo_max_cpus; i++) {
+		unsigned int online = 0;
+
+		snprintf (path, sizeof(path), "/sys/devices/system/cpu/cpu%d/online", i);
+		filep = fopen (path, "r");
+		if (filep) {
+			if (fscanf (filep, "%u", &online) != 1)
+				lpmd_log_warn ("fread failed for %s\n", path);
+			fclose (filep);
+		}
+		else if (!i)
+			online = 1;
+		else
+			break;
+
+		if (!online)
+			continue;
+
+		add_cpu (i, CPUMASK_ONLINE);
+		if (is_cpu_pcore(i))
+			pcores++;
+		else if (is_cpu_ecore(i))
+			ecores++;
+		else if (is_cpu_lcore(i))
+			lcores++;
+	}
+	max_online_cpu = i;
+
+	tdp = get_tdp();
+	lpmd_log_info("Detected %d Pcores, %d Ecores, %d Lcores, TDP %dW\n", pcores, ecores, lcores, tdp);
+	ret = snprintf(lpmd_config->cpu_config, MAX_CONFIG_LEN - 1, " %dP%dE%dL-%dW ", pcores, ecores, lcores, tdp);
+	lpmd_config->cpu_config[ret] = '\0';
+
+	return 0;
+}
+
 int init_cpu(char *cmd_cpus, enum lpm_cpu_process_mode mode, int epp)
 {
 	int ret;
-
-	lpmd_log_info ("Detecting CPUs ...\n");
-	ret = parse_cpu_topology ();
-	if (ret)
-		return ret;
 
 	ret = detect_lpm_cpus (cmd_cpus);
 	if (ret)

--- a/src/lpmd_cpu.c
+++ b/src/lpmd_cpu.c
@@ -1412,17 +1412,6 @@ int has_suv_support(void)
 	return !(in_suv == -1);
 }
 
-int in_hfi_suv_mode(void)
-{
-	int ret;
-
-	lpmd_lock ();
-	ret = in_suv;
-	lpmd_unlock ();
-
-	return ret == HFI_SUV_ENTER;
-}
-
 static int check_cpu_isolate_support(void)
 {
 	return check_cpu_cgroupv2_support ();

--- a/src/lpmd_cpu.c
+++ b/src/lpmd_cpu.c
@@ -656,9 +656,9 @@ int process_epp_epb(void)
 	char path[MAX_STR_LENGTH];
 
 	if (lp_mode_epp == SETTING_IGNORE)
-		lpmd_log_debug ("Ignore EPP\n");
+		lpmd_log_info ("Ignore EPP\n");
 	if (lp_mode_epb == SETTING_IGNORE)
-		lpmd_log_debug ("Ignore EPB\n");
+		lpmd_log_info ("Ignore EPB\n");
 	if (lp_mode_epp == SETTING_IGNORE && lp_mode_epb == SETTING_IGNORE)
 		return 0;
 
@@ -1445,7 +1445,7 @@ static int check_cpu_cgroupv2_support(void)
 
 static int process_cpu_cgroupv2_enter(void)
 {
-	if (lpmd_write_str (PATH_CG2_SUBTREE_CONTROL, "+cpuset", LPMD_LOG_INFO))
+	if (lpmd_write_str (PATH_CG2_SUBTREE_CONTROL, "+cpuset", LPMD_LOG_DEBUG))
 		return 1;
 
 	return update_systemd_cgroup ();
@@ -1455,7 +1455,7 @@ static int process_cpu_cgroupv2_exit(void)
 {
 	restore_systemd_cgroup ();
 
-	return lpmd_write_str (PATH_CG2_SUBTREE_CONTROL, "-cpuset", LPMD_LOG_INFO);
+	return lpmd_write_str (PATH_CG2_SUBTREE_CONTROL, "-cpuset", LPMD_LOG_DEBUG);
 }
 
 static int process_cpu_cgroupv2(int enter)
@@ -1528,21 +1528,21 @@ static int default_dur = -1;
 
 static int _process_cpu_powerclamp_enter(char *cpumask_str, int pct, int dur)
 {
-	if (lpmd_write_str (PATH_CPUMASK, cpumask_str, LPMD_LOG_INFO))
+	if (lpmd_write_str (PATH_CPUMASK, cpumask_str, LPMD_LOG_DEBUG))
 		return 1;
 
 	if (dur > 0) {
-		if (lpmd_read_int (PATH_DURATION, &default_dur, LPMD_LOG_INFO))
+		if (lpmd_read_int (PATH_DURATION, &default_dur, LPMD_LOG_DEBUG))
 			return 1;
 
-		if (lpmd_write_int (PATH_DURATION, dur, LPMD_LOG_INFO))
+		if (lpmd_write_int (PATH_DURATION, dur, LPMD_LOG_DEBUG))
 			return 1;
 	}
 
-	if (lpmd_write_int (PATH_MAXIDLE, pct, LPMD_LOG_INFO))
+	if (lpmd_write_int (PATH_MAXIDLE, pct, LPMD_LOG_DEBUG))
 		return 1;
 
-	if (lpmd_write_int (path_powerclamp, pct, LPMD_LOG_INFO))
+	if (lpmd_write_int (path_powerclamp, pct, LPMD_LOG_DEBUG))
 		return 1;
 
 	return 0;
@@ -1558,10 +1558,10 @@ static int process_cpu_powerclamp_enter(void)
 
 static int process_cpu_powerclamp_exit()
 {
-	if (lpmd_write_int (PATH_DURATION, default_dur, LPMD_LOG_INFO))
+	if (lpmd_write_int (PATH_DURATION, default_dur, LPMD_LOG_DEBUG))
 		return 1;
 
-	return lpmd_write_int (path_powerclamp, 0, LPMD_LOG_INFO);
+	return lpmd_write_int (path_powerclamp, 0, LPMD_LOG_DEBUG);
 }
 
 static int process_cpu_powerclamp(int enter)
@@ -1691,7 +1691,7 @@ static int process_cpu_isolate_enter(void)
 		closedir (dir);
 	}
 
-	if (lpmd_write_str ("/sys/fs/cgroup/lpm/cpuset.cpus.partition", "member", LPMD_LOG_INFO))
+	if (lpmd_write_str ("/sys/fs/cgroup/lpm/cpuset.cpus.partition", "member", LPMD_LOG_DEBUG))
 		return 1;
 
 	if (!CPU_EQUAL_S(size_cpumask, cpumasks[lpm_cpus_cur].mask, cpumasks[CPUMASK_ONLINE].mask)) {
@@ -1712,11 +1712,11 @@ static int process_cpu_isolate_enter(void)
 
 static int process_cpu_isolate_exit(void)
 {
-	if (lpmd_write_str ("/sys/fs/cgroup/lpm/cpuset.cpus.partition", "member", LPMD_LOG_INFO))
+	if (lpmd_write_str ("/sys/fs/cgroup/lpm/cpuset.cpus.partition", "member", LPMD_LOG_DEBUG))
 		return 1;
 
 	if (lpmd_write_str ("/sys/fs/cgroup/lpm/cpuset.cpus", get_cpus_str (CPUMASK_ONLINE),
-						LPMD_LOG_INFO))
+						LPMD_LOG_DEBUG))
 		return 1;
 
 	return 0;

--- a/src/lpmd_cpu.c
+++ b/src/lpmd_cpu.c
@@ -388,6 +388,21 @@ void reset_cpus(enum cpumask_idx idx)
 	lpm_cpus_cur = CPUMASK_LPM_DEFAULT;
 }
 
+void copy_cpu_mask_exclude(enum cpumask_idx source, enum cpumask_idx dest, enum cpumask_idx exlude)
+{
+	int i;
+
+	for (i = 0; i < topo_max_cpus; i++) {
+		if (!CPU_ISSET_S(i, size_cpumask, cpumasks[source].mask))
+			continue;
+
+		if (CPU_ISSET_S(i, size_cpumask, cpumasks[exlude].mask))
+			continue;
+
+		_add_cpu(i, dest);
+	}
+}
+
 int set_lpm_cpus(enum cpumask_idx new)
 {
 	if (lpm_cpus_cur == new)

--- a/src/lpmd_hfi.c
+++ b/src/lpmd_hfi.c
@@ -208,6 +208,9 @@ static void process_one_event(int first, int last, int nr)
 		return;
 
 	if (has_cpus (CPUMASK_HFI)) {
+		/* Ignore duplicate event */
+		if (is_equal (CPUMASK_HFI_LAST, CPUMASK_HFI ))
+			return;
 		if (in_hfi_lpm ()) {
 			lpmd_log_debug ("\tUpdate HFI LPM event\n\n");
 		}
@@ -215,6 +218,8 @@ static void process_one_event(int first, int last, int nr)
 			lpmd_log_debug ("\tDetect HFI LPM event\n");
 		}
 		process_lpm (HFI_ENTER);
+		reset_cpus (CPUMASK_HFI_LAST);
+		copy_cpu_mask(CPUMASK_HFI, CPUMASK_HFI_LAST);
 	}
 	else if (has_cpus (CPUMASK_HFI_SUV)) {
 		if (in_suv_lpm ()) {
@@ -228,6 +233,9 @@ static void process_one_event(int first, int last, int nr)
 	}
 	else if (has_cpus (CPUMASK_HFI_BANNED)) {
 		copy_cpu_mask_exclude(CPUMASK_ONLINE, CPUMASK_HFI, CPUMASK_HFI_BANNED);
+		/* Ignore duplicate event */
+		if (is_equal (CPUMASK_HFI_LAST, CPUMASK_HFI ))
+			return;
 		if (in_hfi_lpm ()) {
 			lpmd_log_debug ("\tUpdate HFI LPM event with banned CPUs\n\n");
 		}
@@ -235,6 +243,8 @@ static void process_one_event(int first, int last, int nr)
 			lpmd_log_debug ("\tDetect HFI LPM event with banned CPUs\n");
 		}
 		process_lpm (HFI_ENTER);
+		reset_cpus (CPUMASK_HFI_LAST);
+		copy_cpu_mask(CPUMASK_HFI, CPUMASK_HFI_LAST);
 	}
 	else if (in_hfi_lpm ()) {
 		lpmd_log_debug ("\tHFI LPM recover\n");
@@ -333,6 +343,8 @@ int hfi_init(void)
 	struct nl_sock *sock;
 	struct nl_cb *cb;
 	int mcast_id;
+
+	reset_cpus (CPUMASK_HFI_LAST);
 
 	signal (SIGPIPE, SIG_IGN);
 

--- a/src/lpmd_hfi.c
+++ b/src/lpmd_hfi.c
@@ -202,22 +202,23 @@ static void process_one_event(int first, int last, int nr)
 
 	if (has_cpus (CPUMASK_HFI)) {
 		if (in_hfi_lpm ()) {
-			lpmd_log_debug ("\tRedundant HFI LPM event ignored\n\n");
+			lpmd_log_debug ("\tUpdate HFI LPM event\n\n");
 		}
 		else {
-			lpmd_log_debug ("\tHFI LPM hints detected\n");
-			process_lpm (HFI_ENTER);
+			lpmd_log_debug ("\tDetect HFI LPM event\n");
 		}
+		process_lpm (HFI_ENTER);
 		reset_cpus (CPUMASK_HFI);
 	}
 	else if (has_cpus (CPUMASK_HFI_SUV)) {
 		if (in_suv_lpm ()) {
-			lpmd_log_debug ("\tRedundant HFI SUV event ignored\n\n");
+			lpmd_log_debug ("\tUpdate HFI SUV event\n\n");
 		}
 		else {
-			lpmd_log_debug ("\tHFI SUV hints detected\n");
-			process_suv_mode (HFI_SUV_ENTER);
+			lpmd_log_debug ("\tDetect HFI SUV event\n");
 		}
+//		 TODO: SUV re-enter is not supported for now
+		process_suv_mode (HFI_SUV_ENTER);
 		reset_cpus (CPUMASK_HFI_SUV);
 	}
 	else if (in_hfi_lpm ()) {

--- a/src/lpmd_hfi.c
+++ b/src/lpmd_hfi.c
@@ -196,40 +196,42 @@ static void update_one_cpu(struct perf_cap *perf_cap)
 
 static void process_one_event(int first, int last, int nr)
 {
-	if (nr < 16 || last >= get_max_online_cpu () - 1) {
-		if (has_cpus (CPUMASK_HFI)) {
-			if (in_hfi_lpm ()) {
-				lpmd_log_debug ("\tRedundant HFI LPM event ignored\n\n");
-			}
-			else {
-				lpmd_log_debug ("\tHFI LPM hints detected\n");
-				process_lpm (HFI_ENTER);
-			}
-			reset_cpus (CPUMASK_HFI);
-		}
-		else if (has_cpus (CPUMASK_HFI_SUV)) {
-			if (in_suv_lpm ()) {
-				lpmd_log_debug ("\tRedundant HFI SUV event ignored\n\n");
-			}
-			else {
-				lpmd_log_debug ("\tHFI SUV hints detected\n");
-				process_suv_mode (HFI_SUV_ENTER);
-			}
-			reset_cpus (CPUMASK_HFI_SUV);
-		}
-		else if (in_hfi_lpm ()) {
-			lpmd_log_debug ("\tHFI LPM recover\n");
-//			 Don't override the DETECT_LPM_CPU_DEFAULT so it is auto recovered
-			process_lpm (HFI_EXIT);
-		}
-		else if (in_suv_lpm ()) {
-			lpmd_log_debug ("\tHFI SUV recover\n");
-//			 Don't override the DETECT_LPM_CPU_DEFAULT so it is auto recovered
-			process_suv_mode (HFI_SUV_EXIT);
+	/* Need to update more CPUs */
+	if (nr == 16 && last != get_max_online_cpu ())
+		return;
+
+	if (has_cpus (CPUMASK_HFI)) {
+		if (in_hfi_lpm ()) {
+			lpmd_log_debug ("\tRedundant HFI LPM event ignored\n\n");
 		}
 		else {
-			lpmd_log_info ("\t\t\tUnsupported HFI event ignored\n");
+			lpmd_log_debug ("\tHFI LPM hints detected\n");
+			process_lpm (HFI_ENTER);
 		}
+		reset_cpus (CPUMASK_HFI);
+	}
+	else if (has_cpus (CPUMASK_HFI_SUV)) {
+		if (in_suv_lpm ()) {
+			lpmd_log_debug ("\tRedundant HFI SUV event ignored\n\n");
+		}
+		else {
+			lpmd_log_debug ("\tHFI SUV hints detected\n");
+			process_suv_mode (HFI_SUV_ENTER);
+		}
+		reset_cpus (CPUMASK_HFI_SUV);
+	}
+	else if (in_hfi_lpm ()) {
+		lpmd_log_debug ("\tHFI LPM recover\n");
+//		 Don't override the DETECT_LPM_CPU_DEFAULT so it is auto recovered
+		process_lpm (HFI_EXIT);
+	}
+	else if (in_suv_lpm ()) {
+		lpmd_log_debug ("\tHFI SUV recover\n");
+//		 Don't override the DETECT_LPM_CPU_DEFAULT so it is auto recovered
+		process_suv_mode (HFI_SUV_EXIT);
+	}
+	else {
+		lpmd_log_info ("\t\t\tUnsupported HFI event ignored\n");
 	}
 }
 

--- a/src/lpmd_hfi.c
+++ b/src/lpmd_hfi.c
@@ -196,22 +196,19 @@ static void update_one_cpu(struct perf_cap *perf_cap)
 
 static void process_one_event(int first, int last, int nr)
 {
-	static int in_lpm = 0;
-
 	if (nr < 16 || last >= get_max_online_cpu () - 1) {
 		if (has_cpus (CPUMASK_HFI)) {
-			if (in_lpm) {
+			if (in_hfi_lpm ()) {
 				lpmd_log_debug ("\tRedundant HFI LPM event ignored\n\n");
 			}
 			else {
 				lpmd_log_debug ("\tHFI LPM hints detected\n");
 				process_lpm (HFI_ENTER);
-				in_lpm = 1;
 			}
 			reset_cpus (CPUMASK_HFI);
 		}
 		else if (has_cpus (CPUMASK_HFI_SUV)) {
-			if (in_hfi_suv_mode ()) {
+			if (in_suv_lpm ()) {
 				lpmd_log_debug ("\tRedundant HFI SUV event ignored\n\n");
 			}
 			else {
@@ -220,13 +217,12 @@ static void process_one_event(int first, int last, int nr)
 			}
 			reset_cpus (CPUMASK_HFI_SUV);
 		}
-		else if (in_lpm) {
+		else if (in_hfi_lpm ()) {
 			lpmd_log_debug ("\tHFI LPM recover\n");
 //			 Don't override the DETECT_LPM_CPU_DEFAULT so it is auto recovered
 			process_lpm (HFI_EXIT);
-			in_lpm = 0;
 		}
-		else if (in_hfi_suv_mode ()) {
+		else if (in_suv_lpm ()) {
 			lpmd_log_debug ("\tHFI SUV recover\n");
 //			 Don't override the DETECT_LPM_CPU_DEFAULT so it is auto recovered
 			process_suv_mode (HFI_SUV_EXIT);

--- a/src/lpmd_hfi.c
+++ b/src/lpmd_hfi.c
@@ -271,7 +271,7 @@ static int handle_event(struct nl_msg *n, void *arg)
 				perf_cap.perf = nla_get_u32 (cap);
 				break;
 			case 2:
-				offset += snprintf (buf + offset, MAX_STR_LENGTH - offset, " PERF %4d ",
+				offset += snprintf (buf + offset, MAX_STR_LENGTH - offset, " EFF %4d ",
 									nla_get_u32 (cap));
 				perf_cap.eff = nla_get_u32 (cap);
 				break;

--- a/src/lpmd_hfi.c
+++ b/src/lpmd_hfi.c
@@ -188,6 +188,9 @@ static void update_one_cpu(struct perf_cap *perf_cap)
 	if (perf_cap->cpu < 0)
 		return;
 
+	if (!perf_cap->cpu)
+		reset_cpus (CPUMASK_HFI);
+
 	if (perf_cap->eff == 255 * 4 && has_hfi_lpm_monitor ())
 		add_cpu (perf_cap->cpu, CPUMASK_HFI);
 	if (!perf_cap->perf && !perf_cap->eff && has_hfi_suv_monitor () && suv_bit_set ())
@@ -208,7 +211,6 @@ static void process_one_event(int first, int last, int nr)
 			lpmd_log_debug ("\tDetect HFI LPM event\n");
 		}
 		process_lpm (HFI_ENTER);
-		reset_cpus (CPUMASK_HFI);
 	}
 	else if (has_cpus (CPUMASK_HFI_SUV)) {
 		if (in_suv_lpm ()) {
@@ -219,7 +221,6 @@ static void process_one_event(int first, int last, int nr)
 		}
 //		 TODO: SUV re-enter is not supported for now
 		process_suv_mode (HFI_SUV_ENTER);
-		reset_cpus (CPUMASK_HFI_SUV);
 	}
 	else if (in_hfi_lpm ()) {
 		lpmd_log_debug ("\tHFI LPM recover\n");

--- a/src/lpmd_irq.c
+++ b/src/lpmd_irq.c
@@ -135,9 +135,9 @@ static int irqbalance_ban_cpus(int enter)
 	int first = 1;
 
 	if (lp_mode_irq == SETTING_RESTORE)
-		lpmd_log_info ("\tRestore IRQ affinity (irqbalance)\n");
+		lpmd_log_debug ("\tRestore IRQ affinity (irqbalance)\n");
 	else
-		lpmd_log_info ("\tUpdate IRQ affinity (irqbalance)\n");
+		lpmd_log_debug ("\tUpdate IRQ affinity (irqbalance)\n");
 
 	offset = snprintf (socket_cmd, MAX_STR_LENGTH, "settings cpus %s", irq_str);
 	if (offset >= MAX_STR_LENGTH)
@@ -147,7 +147,7 @@ static int irqbalance_ban_cpus(int enter)
 	clock_gettime (CLOCK_MONOTONIC, &tp1);
 	socket_send_cmd (irq_socket_name, socket_cmd);
 	clock_gettime (CLOCK_MONOTONIC, &tp2);
-	lpmd_log_info ("\tSend socket command %s (%lu ns)\n", socket_cmd,
+	lpmd_log_debug ("\tSend socket command %s (%lu ns)\n", socket_cmd,
 		1000000000UL * (tp2.tv_sec - tp1.tv_sec) + tp2.tv_nsec - tp1.tv_nsec);
 	return 0;
 }
@@ -157,7 +157,7 @@ static int native_restore_irqs(void)
 	char path[MAX_STR_LENGTH];
 	int i;
 
-	lpmd_log_info ("\tRestore IRQ affinity (native)\n");
+	lpmd_log_debug ("\tRestore IRQ affinity (native)\n");
 
 	for (i = 0; i < info->nr_irqs; i++) {
 		char *str = info->irq[i].affinity;
@@ -222,7 +222,7 @@ static int native_update_irqs(void)
 	char *line = NULL;
 	size_t size = 0;
 
-	lpmd_log_info ("\tUpdate IRQ affinity (native)\n");
+	lpmd_log_debug ("\tUpdate IRQ affinity (native)\n");
 
 	filep = fopen ("/proc/interrupts", "r");
 	if (!filep) {
@@ -294,7 +294,7 @@ int process_irqs(int enter, enum lpm_cpu_process_mode mode)
 		return 0;
 
 	if (lp_mode_irq == SETTING_IGNORE) {
-		lpmd_log_info("Ignore IRQ migration\n");
+		lpmd_log_info ("Ignore IRQ migration\n");
 		return 0;
 	}
 

--- a/src/lpmd_irq.c
+++ b/src/lpmd_irq.c
@@ -88,6 +88,8 @@ int set_lpm_irq(cpu_set_t *cpumask, int action)
 		if (lp_mode_irq != SETTING_RESTORE)
 			cpumask_to_hexstr(cpumask, irq_str, MAX_STR_LENGTH);
 	}
+
+	return 0;
 }
 
 static int dump_smp_affinity(void)

--- a/src/lpmd_irq.c
+++ b/src/lpmd_irq.c
@@ -44,7 +44,11 @@
 
 #include "lpmd.h"
 
+char *lp_mode_irq_str;
+
 static char irq_socket_name[64];
+
+static int irqbalance_pid = -1;
 
 #define MAX_IRQS		128
 
@@ -61,6 +65,30 @@ struct info_irqs {
 
 struct info_irqs info_irqs;
 struct info_irqs *info = &info_irqs;
+
+static char irq_str[MAX_STR_LENGTH];
+
+static int lp_mode_irq;
+int set_lpm_irq(cpu_set_t *cpumask, int action)
+{
+	lp_mode_irq = action;
+
+	if (lp_mode_irq == SETTING_IGNORE)
+		return 0;
+
+	if (irqbalance_pid > 0) {
+		if (lp_mode_irq == SETTING_RESTORE)
+			snprintf(irq_str, sizeof("NULL"), "NULL");
+		else {
+			cpumask_to_str_reverse(cpumask, irq_str, MAX_STR_LENGTH);
+			if (irq_str[0] == '\0')
+				snprintf(irq_str, sizeof("NULL"), "NULL");
+		}
+	} else {
+		if (lp_mode_irq != SETTING_RESTORE)
+			cpumask_to_hexstr(cpumask, irq_str, MAX_STR_LENGTH);
+	}
+}
 
 static int dump_smp_affinity(void)
 {
@@ -98,8 +126,6 @@ static int dump_smp_affinity(void)
 #define SOCKET_PATH "irqbalance"
 #define SOCKET_TMPFS "/run/irqbalance"
 
-static int irqbalance_pid = -1;
-
 static int irqbalance_ban_cpus(int enter)
 {
 	char socket_cmd[MAX_STR_LENGTH];
@@ -108,37 +134,15 @@ static int irqbalance_ban_cpus(int enter)
 	int offset;
 	int first = 1;
 
-	dump_smp_affinity();
-
-	if (enter)
-		lpmd_log_info ("\tUpdate IRQ affinity (irqbalance)\n");
-	else
+	if (lp_mode_irq == SETTING_RESTORE)
 		lpmd_log_info ("\tRestore IRQ affinity (irqbalance)\n");
+	else
+		lpmd_log_info ("\tUpdate IRQ affinity (irqbalance)\n");
 
-	offset = snprintf (socket_cmd, sizeof("settings cpus "), "settings cpus ");
-	if (!enter) {
-		offset += snprintf (socket_cmd + offset, sizeof("NULL"), "NULL");
-		goto end;
-	}
-
-	for (cpu = 0; cpu < get_max_cpus (); cpu++) {
-		if (!is_cpu_online (cpu))
-			continue;
-
-		if (!is_cpu_for_lpm (cpu)) {
-			if (MAX_STR_LENGTH <= offset) {
-				lpmd_log_error ("Too many CPUs for socket message\n");
-				return -1;
-			}
-			if (first)
-				offset += snprintf (socket_cmd + offset, MAX_STR_LENGTH - offset, "%d", cpu);
-			else
-				offset += snprintf (socket_cmd + offset, MAX_STR_LENGTH - offset, ",%d", cpu);
-			first = 0;
-		}
-	}
-
-end: socket_cmd[offset] = '\0';
+	offset = snprintf (socket_cmd, MAX_STR_LENGTH, "settings cpus %s", irq_str);
+	if (offset >= MAX_STR_LENGTH)
+		offset = MAX_STR_LENGTH - 1;
+	socket_cmd[offset] = '\0';
 
 	clock_gettime (CLOCK_MONOTONIC, &tp1);
 	socket_send_cmd (irq_socket_name, socket_cmd);
@@ -166,6 +170,8 @@ static int native_restore_irqs(void)
 	return 0;
 }
 
+static int irq_updated;
+
 static int update_one_irq(int irq)
 {
 	FILE *filep;
@@ -178,37 +184,36 @@ static int update_one_irq(int irq)
 		return -1;
 	}
 
-	info->irq[info->nr_irqs].irq = irq;
 
 	snprintf (path, MAX_STR_LENGTH, "/proc/irq/%i/smp_affinity", irq);
 
-	filep = fopen (path, "r");
-	if (!filep)
-		return -1;
+	if (!irq_updated) {
+		info->irq[info->nr_irqs].irq = irq;
+		filep = fopen (path, "r");
+		if (!filep)
+			return -1;
 
-	if (getline (&str, &size, filep) <= 0) {
-		lpmd_log_error ("Failed to get IRQ%d smp_affinity\n", irq);
-		free (str);
+		if (getline (&str, &size, filep) <= 0) {
+			lpmd_log_error ("Failed to get IRQ%d smp_affinity\n", irq);
+			free (str);
+			fclose (filep);
+			return -1;
+		}
+
 		fclose (filep);
-		return -1;
+
+		snprintf (info->irq[info->nr_irqs].affinity, MAX_STR_LENGTH, "%s", str);
+
+		free (str);
+
+		/* Remove the Newline */
+		size = strnlen (info->irq[info->nr_irqs].affinity, MAX_STR_LENGTH);
+		info->irq[info->nr_irqs].affinity[size - 1] = '\0';
+
+		info->nr_irqs++;
 	}
 
-	fclose (filep);
-
-	snprintf (info->irq[info->nr_irqs].affinity, MAX_STR_LENGTH, "%s", str);
-
-	free (str);
-
-	/* Remove the Newline */
-	size = strnlen (info->irq[info->nr_irqs].affinity, MAX_STR_LENGTH);
-	info->irq[info->nr_irqs].affinity[size - 1] = '\0';
-
-	if (lpmd_write_str (path, get_lpm_cpus_hexstr (), LPMD_LOG_DEBUG))
-		return 1;
-
-	info->nr_irqs++;
-
-	return 0;
+	return lpmd_write_str (path, irq_str, LPMD_LOG_DEBUG);
 }
 
 static int native_update_irqs(void)
@@ -270,17 +275,16 @@ static int native_update_irqs(void)
 
 	fclose (filep);
 
+	irq_updated = 1;
 	return 0;
 }
 
 static int native_process_irqs(int enter)
 {
-	dump_smp_affinity();
-
-	if (enter)
-		return native_update_irqs ();
-	else
+	if (lp_mode_irq == SETTING_RESTORE)
 		return native_restore_irqs ();
+	else
+		return native_update_irqs ();
 }
 
 int process_irqs(int enter, enum lpm_cpu_process_mode mode)
@@ -288,6 +292,12 @@ int process_irqs(int enter, enum lpm_cpu_process_mode mode)
 	/* No need to handle IRQs in offline mode */
 	if (mode == LPM_CPU_OFFLINE)
 		return 0;
+
+	if (lp_mode_irq == SETTING_IGNORE) {
+		lpmd_log_info("Ignore IRQ migration\n");
+		return 0;
+	}
+
 	lpmd_log_info ("Process IRQs ...\n");
 	if (irqbalance_pid == -1)
 		return native_process_irqs (enter);

--- a/src/lpmd_proc.c
+++ b/src/lpmd_proc.c
@@ -153,6 +153,14 @@ void set_lpm_itmt(int val)
 	lp_mode_itmt = val;
 }
 
+int get_itmt(void)
+{
+	int val;
+
+	lpmd_read_int(PATH_ITMT_CONTROL, &val, -1);
+	return val;
+}
+
 static int init_itmt(void)
 {
 	return lpmd_read_int(PATH_ITMT_CONTROL, &saved_itmt, -1);

--- a/src/lpmd_proc.c
+++ b/src/lpmd_proc.c
@@ -1020,8 +1020,10 @@ int lpmd_main(void)
 	}
 
 	if (lpmd_config.wlt_hint_enable) {
-		lpmd_config.util_enable = 0;
-		poll_for_wlt(1);
+		if (!lpmd_config.hfi_lpm_enable && !lpmd_config.hfi_suv_enable) {
+			lpmd_config.util_enable = 0;
+			poll_for_wlt(1);
+		}
 	}
 
 	pthread_attr_init (&lpmd_attr);

--- a/src/lpmd_proc.c
+++ b/src/lpmd_proc.c
@@ -754,6 +754,10 @@ int lpmd_main(void)
 
 	lpmd_log_debug ("lpmd_main begin\n");
 
+	ret = check_cpu_capability(&lpmd_config);
+	if (ret)
+		return ret;
+
 //	 Call all lpmd related functions here
 	ret = lpmd_get_config (&lpmd_config);
 	if (ret)

--- a/src/lpmd_proc.c
+++ b/src/lpmd_proc.c
@@ -176,7 +176,7 @@ static int process_itmt(void)
 		return 0;
 	}
 
-	lpmd_log_info ("%s ITMT\n", lp_mode_itmt ? "Enable" : "Disable");
+	lpmd_log_debug ("%s ITMT\n", lp_mode_itmt ? "Enable" : "Disable");
 
 	return lpmd_write_int(PATH_ITMT_CONTROL, lp_mode_itmt, -1);
 }

--- a/src/lpmd_proc.c
+++ b/src/lpmd_proc.c
@@ -80,6 +80,18 @@ int get_cpu_mode(void)
 	return lpmd_config.mode;
 }
 
+static int has_hfi_capability(void)
+{
+	unsigned int eax = 0, ebx = 0, ecx = 0, edx = 0;
+
+	cpuid(6, eax, ebx, ecx, edx);
+	if (eax & (1 << 19)) {
+		lpmd_log_info("HFI capability detected\n");
+		return 1;
+	}
+	return 0;
+}
+
 int has_hfi_lpm_monitor(void)
 {
 	return !!lpmd_config.hfi_lpm_enable;
@@ -716,6 +728,9 @@ int lpmd_main(void)
 
 	if (!has_suv_support () && lpmd_config.hfi_suv_enable)
 		lpmd_config.hfi_suv_enable = 0;
+
+	if (!has_hfi_capability ())
+		lpmd_config.hfi_lpm_enable = 0;
 
 	ret = init_irq ();
 	if (ret)

--- a/src/lpmd_proc.c
+++ b/src/lpmd_proc.c
@@ -237,7 +237,7 @@ static int lpm_can_process(enum lpm_command cmd)
 			}
 			return 0;
 		case HFI_ENTER:
-			if (lpm_state & LPM_USER_OFF)
+			if (lpm_state & (LPM_USER_OFF | LPM_USER_ON))
 				return 0;
 
 			/* Ignore HFI LPM hints when in SUV mode */

--- a/src/lpmd_proc.c
+++ b/src/lpmd_proc.c
@@ -434,9 +434,9 @@ int process_lpm_unlock(enum lpm_command cmd)
 		case USER_EXIT:
 		case UTIL_EXIT:
 			reset_config_state();
-			set_lpm_epp (lpmd_config.lp_mode_epp == SETTING_IGNORE ? SETTING_IGNORE : SETTING_RESTORE);
-			set_lpm_epb (SETTING_IGNORE);
-			set_lpm_itmt (lpmd_config.ignore_itmt ? SETTING_IGNORE : SETTING_RESTORE); /* Restore ITMT */
+			set_lpm_epp (SETTING_RESTORE);
+			set_lpm_epb (SETTING_RESTORE);
+			set_lpm_itmt (SETTING_RESTORE);
 			set_lpm_irq(NULL, SETTING_RESTORE);
 			ret = exit_lpm (cmd);
 			break;
@@ -961,6 +961,8 @@ int lpmd_main(void)
 	ret = init_cpu (lpmd_config.lp_mode_cpus, lpmd_config.mode, lpmd_config.lp_mode_epp);
 	if (ret)
 		return ret;
+
+	init_itmt();
 
 	if (!has_suv_support () && lpmd_config.hfi_suv_enable)
 		lpmd_config.hfi_suv_enable = 0;

--- a/src/lpmd_proc.c
+++ b/src/lpmd_proc.c
@@ -395,15 +395,23 @@ int process_lpm_unlock(enum lpm_command cmd)
 		case HFI_ENTER:
 		case UTIL_ENTER:
 		case USER_AUTO:
+			set_lpm_epp (lpmd_config.lp_mode_epp);
+			ret = enter_lpm (cmd);
+			break;
 		case HFI_SUV_EXIT:
 		case DBUS_SUV_EXIT:
+			set_lpm_epp (SETTING_IGNORE);
 			ret = enter_lpm (cmd);
 			break;
 		case USER_EXIT:
 		case HFI_EXIT:
 		case UTIL_EXIT:
+			set_lpm_epp (lpmd_config.lp_mode_epp == SETTING_IGNORE ? SETTING_IGNORE : SETTING_RESTORE);
+			ret = exit_lpm (cmd);
+			break;
 		case HFI_SUV_ENTER:
 		case DBUS_SUV_ENTER:
+			set_lpm_epp (SETTING_IGNORE);
 			ret = exit_lpm (cmd);
 			break;
 		default:

--- a/src/lpmd_proc.c
+++ b/src/lpmd_proc.c
@@ -396,22 +396,26 @@ int process_lpm_unlock(enum lpm_command cmd)
 		case UTIL_ENTER:
 		case USER_AUTO:
 			set_lpm_epp (lpmd_config.lp_mode_epp);
+			set_lpm_epb (SETTING_IGNORE);
 			ret = enter_lpm (cmd);
 			break;
 		case HFI_SUV_EXIT:
 		case DBUS_SUV_EXIT:
 			set_lpm_epp (SETTING_IGNORE);
+			set_lpm_epb (SETTING_IGNORE);
 			ret = enter_lpm (cmd);
 			break;
 		case USER_EXIT:
 		case HFI_EXIT:
 		case UTIL_EXIT:
 			set_lpm_epp (lpmd_config.lp_mode_epp == SETTING_IGNORE ? SETTING_IGNORE : SETTING_RESTORE);
+			set_lpm_epb (SETTING_IGNORE);
 			ret = exit_lpm (cmd);
 			break;
 		case HFI_SUV_ENTER:
 		case DBUS_SUV_ENTER:
 			set_lpm_epp (SETTING_IGNORE);
+			set_lpm_epb (SETTING_IGNORE);
 			ret = exit_lpm (cmd);
 			break;
 		default:

--- a/src/lpmd_proc.c
+++ b/src/lpmd_proc.c
@@ -733,6 +733,7 @@ int lpmd_main(void)
 	pthread_attr_init (&lpmd_attr);
 	pthread_attr_setdetachstate (&lpmd_attr, PTHREAD_CREATE_DETACHED);
 
+	connect_to_power_profile_daemon ();
 	/*
 	 * lpmd_core_main_loop: is the thread where all LPMD actions take place.
 	 * All other thread send message via pipe to trigger processing
@@ -741,7 +742,6 @@ int lpmd_main(void)
 	if (ret)
 		return LPMD_FATAL_ERROR;
 
-	connect_to_power_profile_daemon ();
 
 	lpmd_log_debug ("lpmd_init succeeds\n");
 

--- a/src/lpmd_proc.c
+++ b/src/lpmd_proc.c
@@ -710,7 +710,7 @@ int lpmd_main(void)
 
 	pthread_mutex_init (&lpmd_mutex, NULL);
 
-	ret = init_cpu (lpmd_config.lp_mode_cpus, lpmd_config.mode);
+	ret = init_cpu (lpmd_config.lp_mode_cpus, lpmd_config.mode, lpmd_config.lp_mode_epp);
 	if (ret)
 		return ret;
 

--- a/src/lpmd_proc.c
+++ b/src/lpmd_proc.c
@@ -585,7 +585,7 @@ void lpmd_notify_hfi_event(void)
 	sleep (1);
 }
 
-#define LPMD_NUM_OF_POLL_FDS	4
+#define LPMD_NUM_OF_POLL_FDS	5
 
 static pthread_t lpmd_core_main;
 static pthread_attr_t lpmd_attr;
@@ -596,6 +596,142 @@ static int poll_fd_cnt;
 static int idx_pipe_fd = -1;
 static int idx_uevent_fd = -1;
 static int idx_hfi_fd = -1;
+
+static int wlt_fd;
+static int idx_wlt_fd = -1;
+
+/* WLT hints parsing */
+typedef enum {
+	WLT_IDLE,
+	WLT_BATTERY_LIFE,
+	WLT_SUSTAINED,
+	WLT_BURSTY,
+	WLT_INVALID,
+} wlt_type_t;
+
+// Workload type classification
+#define WORKLOAD_NOTIFICATION_DELAY_ATTRIBUTE "/sys/bus/pci/devices/0000:00:04.0/workload_hint/notification_delay_ms"
+#define WORKLOAD_ENABLE_ATTRIBUTE "/sys/bus/pci/devices/0000:00:04.0/workload_hint/workload_hint_enable"
+#define WORKLOAD_TYPE_INDEX_ATTRIBUTE  "/sys/bus/pci/devices/0000:00:04.0/workload_hint/workload_type_index"
+
+#define NOTIFICATION_DELAY	100
+
+// Clear workload type notifications
+static void exit_wlt()
+{
+	int fd;
+
+	/* Disable feature via sysfs knob */
+	fd = open(WORKLOAD_ENABLE_ATTRIBUTE, O_RDWR);
+	if (fd < 0)
+		return;
+
+	// Disable WLT notification
+	if (write(fd, "0\n", 2) < 0) {
+		close (fd);
+		return;
+	}
+
+	close(fd);
+}
+
+// Initialize Workload type notifications
+static int init_wlt()
+{
+	char delay_str[64];
+	int fd;
+
+	lpmd_log_debug ("init_wlt begin\n");
+
+	// Set notification delay
+	fd = open(WORKLOAD_NOTIFICATION_DELAY_ATTRIBUTE, O_RDWR);
+	if (fd < 0)
+		return fd;
+
+	sprintf(delay_str, "%d\n", NOTIFICATION_DELAY);
+
+	if (write(fd, delay_str, strlen(delay_str)) < 0) {
+		close(fd);
+		return -1;
+	}
+
+	close(fd);
+
+	// Enable WLT notification
+	fd = open(WORKLOAD_ENABLE_ATTRIBUTE, O_RDWR);
+	if (fd < 0)
+		return fd;
+
+	if (write(fd, "1\n", 2) < 0) {
+		close(fd);
+		return -1;
+	}
+
+	close(fd);
+
+	// Open FD for workload type attribute
+	fd = open(WORKLOAD_TYPE_INDEX_ATTRIBUTE, O_RDONLY);
+	if (fd < 0) {
+		exit_wlt();
+		return fd;
+	}
+
+	lpmd_log_debug ("init_wlt end wlt fd:%d\n", fd);
+
+	return fd;
+}
+
+// Read current Workload type
+static int read_wlt(int fd)
+{
+	char index_str[4];
+	int index, ret;
+
+	if (fd < 0)
+		return WLT_INVALID;
+
+	if ((lseek(fd, 0L, SEEK_SET)) < 0)
+		return WLT_INVALID;
+
+	if (read(fd, index_str, sizeof(index_str)) < 0)
+		return WLT_INVALID;
+
+	 ret = sscanf(index_str, "%d", &index);
+	 if (ret < 0)
+		return WLT_INVALID;
+
+	lpmd_log_debug("wlt:%d\n", index);
+
+	return index;
+}
+
+static void poll_for_wlt(int enable)
+{
+	static int wlt_enabled_once = 0;
+
+	if (wlt_fd <= 0) {
+		if (enable) {
+			wlt_fd = init_wlt();
+			if (wlt_fd < 0)
+				return;
+		} else {
+			return;
+		}
+	}
+
+	if (enable) {
+		idx_wlt_fd = poll_fd_cnt;
+		poll_fds[idx_wlt_fd].fd = wlt_fd;
+		poll_fds[idx_wlt_fd].events = POLLPRI;
+		poll_fds[idx_wlt_fd].revents = 0;
+		if (!wlt_enabled_once)
+			poll_fd_cnt++;
+		wlt_enabled_once = 1;
+	} else if (idx_wlt_fd >= 0) {
+		poll_fds[idx_wlt_fd].fd = -1;
+		idx_wlt_fd = -1;
+	}
+}
 
 #include <gio/gio.h>
 
@@ -724,7 +860,7 @@ static void* lpmd_core_main_loop(void *arg)
 
 		/* Time out, need to choose next util state and interval */
 		if (n == 0 && interval > 0)
-			interval = periodic_util_update (&lpmd_config);
+			interval = periodic_util_update (&lpmd_config, -1);
 
 		if (idx_pipe_fd >= 0 && (poll_fds[idx_pipe_fd].revents & POLLIN)) {
 //			 process message written on pipe here
@@ -749,6 +885,14 @@ static void* lpmd_core_main_loop(void *arg)
 		if (idx_hfi_fd >= 0 && (poll_fds[idx_hfi_fd].revents & POLLIN)) {
 			hfi_receive ();
 		}
+
+		if (idx_wlt_fd >= 0 && (poll_fds[idx_wlt_fd].revents & POLLPRI)) {
+			int wlt_index;
+
+			wlt_index = read_wlt(poll_fds[idx_wlt_fd].fd);
+			interval = periodic_util_update (&lpmd_config, wlt_index);
+		}
+
 
 	}
 
@@ -775,6 +919,7 @@ static void build_default_config_state(void)
 	state->epp = lpmd_config.lp_mode_epp;
 	state->epb = SETTING_IGNORE;
 	state->valid = 1;
+	state->wlt_type = -1;
 	snprintf(state->active_cpus, MAX_STR_LENGTH, "%s", get_cpus_str(CPUMASK_LPM_DEFAULT));
 
 	state = &lpmd_config.config_states[1];
@@ -789,6 +934,7 @@ static void build_default_config_state(void)
 	state->epp = lpmd_config.lp_mode_epp == SETTING_IGNORE ? SETTING_IGNORE : SETTING_RESTORE;
 	state->epb = SETTING_IGNORE;
 	state->valid = 1;
+	state->wlt_type = -1;
 	snprintf(state->active_cpus, MAX_STR_LENGTH, "%s", get_cpus_str(CPUMASK_ONLINE));
 
 	lpmd_config.config_state_count = 2;
@@ -871,6 +1017,11 @@ int lpmd_main(void)
 			poll_fds[idx_hfi_fd].revents = 0;
 			poll_fd_cnt++;
 		}
+	}
+
+	if (lpmd_config.wlt_hint_enable) {
+		lpmd_config.util_enable = 0;
+		poll_for_wlt(1);
 	}
 
 	pthread_attr_init (&lpmd_attr);

--- a/src/lpmd_proc.c
+++ b/src/lpmd_proc.c
@@ -311,21 +311,9 @@ int enter_lpm(enum lpm_command cmd)
 
 	time_start ();
 
-	switch (cmd) {
-		case USER_ENTER:
-		case UTIL_ENTER:
-			set_lpm_cpus (CPUMASK_LPM_DEFAULT);
-			break;
-		case HFI_ENTER:
-			set_lpm_cpus (CPUMASK_HFI);
-			break;
-		default:
+	if (cmd != USER_ENTER && cmd != UTIL_ENTER && cmd != HFI_ENTER) {
 			lpmd_log_info ("Unsupported LPM reason %d\n", cmd);
 			return 1;
-	}
-	if (!has_lpm_cpus ()) {
-		lpmd_log_error ("No LPM CPUs available\n");
-		return 1;
 	}
 
 	lpmd_log_msg ("------ Enter Low Power Mode (%10s) --- %s", lpm_cmd_str[cmd], get_time ());
@@ -404,6 +392,7 @@ int process_lpm_unlock(enum lpm_command cmd)
 			set_lpm_epb (SETTING_IGNORE);
 			set_lpm_itmt (lpmd_config.ignore_itmt ? SETTING_IGNORE : 0); /* Disable ITMT */
 			set_lpm_irq(get_cpumask(CPUMASK_LPM_DEFAULT), 1);
+			set_lpm_cpus (CPUMASK_LPM_DEFAULT);
 			ret = enter_lpm (cmd);
 			break;
 		case HFI_SUV_EXIT:
@@ -412,6 +401,7 @@ int process_lpm_unlock(enum lpm_command cmd)
 			set_lpm_epb (SETTING_IGNORE);
 			set_lpm_itmt (SETTING_IGNORE);
 			set_lpm_irq(NULL, SETTING_IGNORE);	/* SUV ignores IRQ */
+			set_lpm_cpus (CPUMASK_HFI_SUV);
 			ret = enter_lpm (cmd);
 			break;
 		case HFI_ENTER:
@@ -419,8 +409,10 @@ int process_lpm_unlock(enum lpm_command cmd)
 			set_lpm_epb (SETTING_IGNORE);
 			set_lpm_itmt (0);	/* HFI always disables ITMT */
 			set_lpm_irq(NULL, SETTING_IGNORE);	/* HFI ignores IRQ */
+			set_lpm_cpus (CPUMASK_HFI);
 			ret = enter_lpm (cmd);
 			break;
+		/* exit_lpm does not require to invoke set_lpm_cpus() */
 		case USER_EXIT:
 		case UTIL_EXIT:
 			set_lpm_epp (lpmd_config.lp_mode_epp == SETTING_IGNORE ? SETTING_IGNORE : SETTING_RESTORE);

--- a/src/lpmd_proc.c
+++ b/src/lpmd_proc.c
@@ -693,7 +693,8 @@ static int read_wlt(int fd)
 	if ((lseek(fd, 0L, SEEK_SET)) < 0)
 		return WLT_INVALID;
 
-	if (read(fd, index_str, sizeof(index_str)) < 0)
+	ret = read(fd, index_str, sizeof(index_str));
+	if (ret <= 0)
 		return WLT_INVALID;
 
 	 ret = sscanf(index_str, "%d", &index);

--- a/src/lpmd_proc.c
+++ b/src/lpmd_proc.c
@@ -151,6 +151,16 @@ enum lpm_state {
 /* Force off by default */
 int lpm_state = LPM_USER_OFF;
 
+int in_hfi_lpm(void)
+{
+	return lpm_state & LPM_HFI_ON;
+}
+
+int in_suv_lpm(void)
+{
+	return lpm_state & LPM_SUV_ON;
+}
+
 /*
  * 1: request valid and already satisfied. 0: respond valid and need to continue to process. -1: request invalid
  */

--- a/src/lpmd_util.c
+++ b/src/lpmd_util.c
@@ -339,13 +339,13 @@ static int enter_state(lpmd_config_state_t *state, int bsys, int bcpu)
 {
 	static int interval = DEFAULT_POLL_RATE_MS;
 
-        state->entry_load_sys = bsys;
-        state->entry_load_cpu = bcpu;
+	state->entry_load_sys = bsys;
+	state->entry_load_cpu = bcpu;
 
 	/* Adjust polling interval only */
 	if (state == current_state) {
 		if (state->poll_interval_increment > 0) {
-			interval +=  state->poll_interval_increment;
+			interval += state->poll_interval_increment;
 		}
 		/* Adaptive polling interval based on cpu utilization */
 		if (state->poll_interval_increment == -1) {
@@ -353,34 +353,34 @@ static int enter_state(lpmd_config_state_t *state, int bsys, int bcpu)
 			interval /= 100;
 			interval *= 100;
 		}
-		if (state->min_poll_interval && interval <  state->min_poll_interval)
+		if (state->min_poll_interval && interval < state->min_poll_interval)
 			interval = state->min_poll_interval;
-		if (state->max_poll_interval && interval >  state->max_poll_interval)
+		if (state->max_poll_interval && interval > state->max_poll_interval)
 			interval = state->max_poll_interval;
 		return interval;
 	}
 
-	set_lpm_epp (state->epp);
-	set_lpm_epb (state->epb);
-	set_lpm_itmt (state->itmt_state);
+	set_lpm_epp(state->epp);
+	set_lpm_epb(state->epb);
+	set_lpm_itmt(state->itmt_state);
 
 	if (state->active_cpus[0] != '\0') {
-		reset_cpus (CPUMASK_UTIL);
-		parse_cpu_str (state->active_cpus, CPUMASK_UTIL);
+		reset_cpus(CPUMASK_UTIL);
+		parse_cpu_str(state->active_cpus, CPUMASK_UTIL);
 		if (state->irq_migrate != SETTING_IGNORE)
 			set_lpm_irq(get_cpumask(CPUMASK_UTIL), 1);
 		else
 			set_lpm_irq(NULL, SETTING_IGNORE);
-		set_lpm_cpus (CPUMASK_UTIL);
+		set_lpm_cpus(CPUMASK_UTIL);
 	} else {
 		set_lpm_irq(NULL, SETTING_IGNORE);
-		set_lpm_cpus(CPUMASK_MAX);	/* Ignore Task migration */
+		set_lpm_cpus(CPUMASK_MAX); /* Ignore Task migration */
 	}
 
-	process_lpm (UTIL_ENTER);
+	process_lpm(UTIL_ENTER);
 
-        if (state->min_poll_interval)
-                interval = state->min_poll_interval;
+	if (state->min_poll_interval)
+		interval = state->min_poll_interval;
 	else
 		interval = DEFAULT_POLL_RATE_MS;
 
@@ -400,8 +400,8 @@ static int process_next_config_state(lpmd_config_t *config)
 	// Check for new state
 	for (i = 0; i < config->config_state_count; ++i) {
 		state = &config->config_states[i];
-		if (state_match (state, busy_sys, busy_cpu)) {
-			interval = enter_state (state, busy_sys, busy_cpu);
+		if (state_match(state, busy_sys, busy_cpu)) {
+			interval = enter_state(state, busy_sys, busy_cpu);
 			break;
 		}
 	}
@@ -411,9 +411,18 @@ static int process_next_config_state(lpmd_config_t *config)
 
 	get_epp_epb(&epp, epp_str, 32, &epb);
 	if (epp >= 0)
-		lpmd_log_info ("[%d/%d] %12s: bsys: %3d.%02d, bcpu: %3d.%02d, epp %20d, epb %3d, itmt %2d, interval %4d\n", current_state->id, config->config_state_count, current_state->name, busy_sys / 100, busy_sys % 100, busy_cpu / 100, busy_cpu % 100, epp, epb, get_itmt(), interval);
+		lpmd_log_info(
+				"[%d/%d] %12s: bsys: %3d.%02d, bcpu: %3d.%02d, epp %20d, epb %3d, itmt %2d, interval %4d\n",
+				current_state->id, config->config_state_count,
+				current_state->name, busy_sys / 100, busy_sys % 100,
+				busy_cpu / 100, busy_cpu % 100, epp, epb, get_itmt(), interval);
 	else
-		lpmd_log_info ("[%d/%d] %12s: bsys: %3d.%02d, bcpu: %3d.%02d, epp %20s, epb %3d, itmt %2d, interval %4d\n", current_state->id, config->config_state_count, current_state->name, busy_sys / 100, busy_sys % 100, busy_cpu / 100, busy_cpu % 100, epp_str, epb, get_itmt(), interval);
+		lpmd_log_info(
+				"[%d/%d] %12s: bsys: %3d.%02d, bcpu: %3d.%02d, epp %20s, epb %3d, itmt %2d, interval %4d\n",
+				current_state->id, config->config_state_count,
+				current_state->name, busy_sys / 100, busy_sys % 100,
+				busy_cpu / 100, busy_cpu % 100, epp_str, epb, get_itmt(),
+				interval);
 
 	return interval;
 }

--- a/src/lpmd_util.c
+++ b/src/lpmd_util.c
@@ -507,7 +507,6 @@ int periodic_util_update(lpmd_config_t *lpmd_config, int wlt_index)
 int util_init(lpmd_config_t *lpmd_config)
 {
 	lpmd_config_state_t *state;
-	lpmd_config_state_t *last_valid = NULL;
 	int nr_state = 0;
 	int i, ret;
 	size_t size;
@@ -517,8 +516,10 @@ int util_init(lpmd_config_t *lpmd_config)
 
 		if (state->active_cpus[0] != '\0') {
 			ret = parse_cpu_str(state->active_cpus, CPUMASK_UTIL);
-			if (ret <= 0)
+			if (ret <= 0) {
+				state->valid = 0;
 				continue;
+			}
 		}
 
 		if (!state->min_poll_interval)
@@ -528,13 +529,10 @@ int util_init(lpmd_config_t *lpmd_config)
 		if (!state->poll_interval_increment)
 			state->poll_interval_increment = -1;
 
-
 		state->entry_system_load_thres *= 100;
 		state->enter_cpu_load_thres *= 100;
 		state->exit_cpu_load_thres *= 100;
 
-		state->valid = 1;
-		last_valid = state;
 		nr_state++;
 	}
 


### PR DESCRIPTION
intel_lpmd 0.0.4 release, including

1. Enhance HFI monitor so that it can handle back-to-back HFI LPM hints.
    Previously it only handles first HFI LPM hints and ignore the sub-sequential HFI LPM hints until it exits Low Power mode.

2. Enhance HFI monitor to handle HFI hints for banned CPUs.
    
3. Introduce support for multiple Low Power states.
    With this, intel_lpmd can define multiple Low Power states that have different
    requirements for EPP/EPB/ITMT setting, IRQ migration, and task migration.
    And enter different Low Power state based on different utilization threshold.
 
4. Introduce support for work load type hint.
    Intel firmware is able to predict workload type and expose this hint to userspace.
    Add support to define Low Power states and switch between them based on workload type hint.
    
5. Allow change EPP during Low Power modes transition.
    
6. Minor fixes and cleanups.