### PR TITLE
Fix compile warnings

### DIFF
--- a/src/lpmd_cpu.c
+++ b/src/lpmd_cpu.c
@@ -564,7 +564,6 @@ end:
 int set_epp(char *path, int val, char *str)
 {
 	FILE *filep;
-	int epp;
 	int ret;
 
 	filep = fopen (path, "r+");
@@ -1756,7 +1755,7 @@ static int get_tdp(void)
 	DIR *dir;
 	struct dirent *entry;
 	int ret;
-	char path[MAX_STR_LENGTH];
+	char path[MAX_STR_LENGTH * 2];
 	char str[MAX_STR_LENGTH];
 	char *pos;
 	int tdp = 0;
@@ -1774,7 +1773,7 @@ static int get_tdp(void)
 		if (strncmp(entry->d_name, "intel-rapl", strlen("intel-rapl")))
 			continue;
 
-		snprintf (path, MAX_STR_LENGTH, "%s/%s/name", PATH_RAPL, entry->d_name);
+		snprintf (path, MAX_STR_LENGTH * 2, "%s/%s/name", PATH_RAPL, entry->d_name);
 		filep = fopen (path, "r");
 		if (!filep)
 			continue;
@@ -1788,7 +1787,7 @@ static int get_tdp(void)
 		if (strncmp(str, "package", strlen("package")))
 			continue;
 
-		snprintf (path, MAX_STR_LENGTH, "%s/%s/constraint_0_max_power_uw", PATH_RAPL, entry->d_name);
+		snprintf (path, MAX_STR_LENGTH * 2, "%s/%s/constraint_0_max_power_uw", PATH_RAPL, entry->d_name);
 		filep = fopen (path, "r");
 		if (!filep)
 			continue;

--- a/src/lpmd_irq.c
+++ b/src/lpmd_irq.c
@@ -132,9 +132,7 @@ static int irqbalance_ban_cpus(int enter)
 {
 	char socket_cmd[MAX_STR_LENGTH];
 	struct timespec tp1, tp2;
-	int cpu;
 	int offset;
-	int first = 1;
 
 	if (lp_mode_irq == SETTING_RESTORE)
 		lpmd_log_debug ("\tRestore IRQ affinity (irqbalance)\n");

--- a/src/lpmd_util.c
+++ b/src/lpmd_util.c
@@ -98,7 +98,6 @@ static int parse_proc_stat(void)
 	FILE *filep;
 	int i;
 	int val;
-	int pos = 0;
 	int count = get_max_online_cpu() + 1;
 	int sys_idx = count - 1;
 	int size = sizeof(struct proc_stat_info) * count;
@@ -509,7 +508,6 @@ int util_init(lpmd_config_t *lpmd_config)
 	lpmd_config_state_t *state;
 	int nr_state = 0;
 	int i, ret;
-	size_t size;
 
 	for (i = 0; i < lpmd_config->config_state_count; i++) {
 		state = &lpmd_config->config_states[i];


### PR DESCRIPTION
Fix below compile warnings

src/lpmd_cpu.c: In function ‘set_epp’:
src/lpmd_cpu.c:567:13: warning: unused variable ‘epp’ [-Wunused-variable]
  567 |         int epp;
      |             ^~~
src/lpmd_cpu.c: In function ‘get_tdp’:
src/lpmd_cpu.c:1777:53: warning: ‘%s’ directive output may be truncated writing up to 255 bytes into a region of size 236 [-Wformat-truncation=]
 1777 |                 snprintf (path, MAX_STR_LENGTH, "%s/%s/name", PATH_RAPL, entry->d_name);
      |                                                     ^~
src/lpmd_cpu.c:1777:17: note: ‘snprintf’ output between 26 and 281 bytes into a destination of size 256
 1777 |                 snprintf (path, MAX_STR_LENGTH, "%s/%s/name", PATH_RAPL, entry->d_name);
      |                 ^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
src/lpmd_cpu.c:1791:53: warning: ‘%s’ directive output may be truncated writing up to 255 bytes into a region of size 236 [-Wformat-truncation=]
 1791 |                 snprintf (path, MAX_STR_LENGTH, "%s/%s/constraint_0_max_power_uw", PATH_RAPL, entry->d_name);
      |                                                     ^~
src/lpmd_cpu.c:1791:17: note: ‘snprintf’ output between 47 and 302 bytes into a destination of size 256
 1791 |                 snprintf (path, MAX_STR_LENGTH, "%s/%s/constraint_0_max_power_uw", PATH_RAPL, entry->d_name);
      |                 ^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
  CC       src/intel_lpmd-lpmd_helpers.o
  CC       src/intel_lpmd-lpmd_hfi.o
  CC       src/intel_lpmd-lpmd_irq.o
src/lpmd_irq.c: In function ‘irqbalance_ban_cpus’:
src/lpmd_irq.c:137:13: warning: unused variable ‘first’ [-Wunused-variable]
  137 |         int first = 1;
      |             ^~~~~
src/lpmd_irq.c:135:13: warning: unused variable ‘cpu’ [-Wunused-variable]
  135 |         int cpu;
      |             ^~~
  CC       src/intel_lpmd-lpmd_socket.o
  CC       src/intel_lpmd-lpmd_util.o
src/lpmd_util.c: In function ‘parse_proc_stat’:
src/lpmd_util.c:101:13: warning: unused variable ‘pos’ [-Wunused-variable]
  101 |         int pos = 0;
      |             ^~~
src/lpmd_util.c: In function ‘util_init’:
src/lpmd_util.c:512:16: warning: unused variable ‘size’ [-Wunused-variable]
  512 |         size_t size;
      |                ^~~~