### PR TITLE
intel_lpmd: intel_lpmd 0.0.5 release

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -1,7 +1,7 @@
 AC_PREREQ([2.70])
 
 m4_define([lpmd_major_version], [0])
-m4_define([lpmd_minor_version], [0.4])
+m4_define([lpmd_minor_version], [0.5])
 m4_define([lpmd_version],
           [lpmd_major_version.lpmd_minor_version])
 


### PR DESCRIPTION
This release only includes a series of fixes/cleanups for v0.0.4.
    1. Fix compiling warnings with -Wall.
    2. Remove unintended default config file change to keep it unchanged
       since v0.0.3.