### PR TITLE
intel_lpmd: intel_lpmd 0.0.6 release

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -1,7 +1,7 @@
 AC_PREREQ(1.0)
 
 m4_define([lpmd_major_version], [0])
-m4_define([lpmd_minor_version], [0.5])
+m4_define([lpmd_minor_version], [0.6])
 m4_define([lpmd_version],
           [lpmd_major_version.lpmd_minor_version])
 


### PR DESCRIPTION
This release
- removes the automake and autoconf improvements because a regression is found.
- deprecates the dbus-glib dependency.