### PR TITLE
lpmd_cpu: Fix compiler above array bound error

### DIFF
--- a/src/lpmd_cpu.c
+++ b/src/lpmd_cpu.c
@@ -402,10 +402,14 @@ int add_cpu(int cpu, enum cpumask_idx idx)
 	if (idx & (CPUMASK_HFI | CPUMASK_HFI_SUV | CPUMASK_HFI_BANNED))
 		return 0;
 
-	if (idx == CPUMASK_LPM_DEFAULT)
+	if (idx == CPUMASK_LPM_DEFAULT) {
 		lpmd_log_info ("\tDetected %s CPU%d\n", cpumasks[idx].name, cpu);
-	else
-		lpmd_log_debug ("\tDetected %s CPU%d\n", cpumasks[idx].name, cpu);
+	} else {
+		if (idx < CPUMASK_MAX)
+			lpmd_log_debug ("\tDetected %s CPU%d\n", cpumasks[idx].name, cpu);
+		else
+			lpmd_log_debug ("\tIncorrect CPU ID for CPU%d\n", cpu);
+	}
 
 	return 0;
 }


### PR DESCRIPTION
if the compiler parameter `-Werror=array-bounds` was applied, the compiler complained about the "above array bound" error. This work added a test to ensure the index was not greater than the max array index.

```
src/lpmd_cpu.c: In function ‘add_cpu’:
src/lpmd_cpu.c:408:66: error: array subscript 8 is above array bounds of ‘struct lpm_cpus[7]’ [-Werror=array-bounds=]
  408 |                 lpmd_log_debug ("\tDetected %s CPU%d\n", cpumasks[idx].name, cpu);
      |                                                          ~~~~~~~~^~~~~
src/lpmd_cpu.c:67:24: note: while referencing ‘cpumasks’
   67 | static struct lpm_cpus cpumasks[CPUMASK_MAX] = {
      |                        ^~~~~~~~
cc1: all warnings being treated as errors
make[2]: *** [Makefile:686: src/intel_lpmd-lpmd_cpu.o] Error 1
make[1]: *** [Makefile:868: all-recursive] Error 1
make: *** [Makefile:459: all] Error 2
```