### PR TITLE
Fix ret may hold a negative value

### DIFF
--- a/src/lpmd_cpu.c
+++ b/src/lpmd_cpu.c
@@ -1881,7 +1881,6 @@ int check_cpu_capability(lpmd_config_t *lpmd_config)
 	tdp = get_tdp();
 	lpmd_log_info("Detected %d Pcores, %d Ecores, %d Lcores, TDP %dW\n", pcores, ecores, lcores, tdp);
 	ret = snprintf(lpmd_config->cpu_config, MAX_CONFIG_LEN - 1, " %dP%dE%dL-%dW ", pcores, ecores, lcores, tdp);
-	lpmd_config->cpu_config[ret] = '\0';
 
 	return 0;
 }


### PR DESCRIPTION
snprintf() may return a negative value when an output error is encountered. A negative index can lead to reading or writing outside the bounds of an array. Moreover, snprintf() puts a '\0' at the end of the string so we don't have to put a '\0' manually.

* The functions snprintf() and vsnprintf() write at most size bytes   (including the terminating null byte ('\0')) to str.