### PR TITLE
Allow probe without platform check

### DIFF
--- a/man/intel_lpmd.8
+++ b/man/intel_lpmd.8
@@ -75,6 +75,10 @@ log severity: can be info or debug
 .B --dbus-enable
 Enable Dbus server to receive requests via Dbus
 
+.TP
+.B --ignore-platform-check
+Ignore platform check
+
 .SH EXAMPLES
 .TP
 .B intel_lpmd --loglevel=info --no-daemon --dbus-enable

--- a/man/intel_lpmd.8
+++ b/man/intel_lpmd.8
@@ -75,10 +75,6 @@ log severity: can be info or debug
 .B --dbus-enable
 Enable Dbus server to receive requests via Dbus
 
-.TP
-.B --dry-run
-Dry run without taking any action for debugging purpose.
-
 .SH EXAMPLES
 .TP
 .B intel_lpmd --loglevel=info --no-daemon --dbus-enable

--- a/src/lpmd.h
+++ b/src/lpmd.h
@@ -225,6 +225,7 @@ int set_lpm_cpus(enum cpumask_idx idx);
 
 /* lpmd_main.c */
 int in_debug_mode(void);
+int do_platform_check(void);
 
 /* lpmd_proc.c: interfaces */
 int lpmd_lock(void);

--- a/src/lpmd_cpu.c
+++ b/src/lpmd_cpu.c
@@ -882,6 +882,11 @@ static int detect_supported_cpu(lpmd_config_t *lpmd_config)
 	lpmd_log_info("%u CPUID levels; family:model:stepping 0x%x:%x:%x (%u:%u:%u)\n",
 			max_level, family, model, stepping, family, model, stepping);
 
+	if (!do_platform_check()) {
+		lpmd_log_info("Ignore platform check\n");
+		goto end;
+	}
+
 	/* Need CPUID.1A to detect CPU core type */
         if (max_level < 0x1a) {
 		lpmd_log_info("CPUID leaf 0x1a not supported, unable to detect CPU type\n");
@@ -927,6 +932,7 @@ static int detect_supported_cpu(lpmd_config_t *lpmd_config)
 		return -1;
 	}
 
+end:
 	lpmd_config->cpu_family = family;
 	lpmd_config->cpu_model = model;
 

--- a/src/lpmd_main.c
+++ b/src/lpmd_main.c
@@ -58,6 +58,16 @@ static gboolean use_syslog;
 // Disable dbus
 static gboolean dbus_enable;
 
+static gboolean ignore_platform_check = FALSE;
+
+int do_platform_check(void)
+{
+	if (ignore_platform_check)
+		return 0;
+
+	return 1;
+}
+
 static GMainLoop *g_main_loop;
 
 #ifdef GDBUS
@@ -180,6 +190,7 @@ int main(int argc, char *argv[])
 			  { "loglevel=info", 0, 0, G_OPTION_ARG_NONE, &log_info, N_ ("Log severity: info level and up"), NULL },
 			  { "loglevel=debug", 0, 0, G_OPTION_ARG_NONE, &log_debug, N_ ("Log severity: debug level and up: Max logging"), NULL },
 			  { "dbus-enable", 0, 0, G_OPTION_ARG_NONE, &dbus_enable, N_ ( "Enable Dbus"), NULL },
+			  { "ignore-platform-check", 0, 0, G_OPTION_ARG_NONE, &ignore_platform_check, N_ ( "Ignore platform check"), NULL },
 			  { NULL, 0, 0, G_OPTION_ARG_NONE, NULL, NULL, NULL } };
 
 	if (!g_module_supported ()) {


### PR DESCRIPTION
current code uses a strict platform check to launch the service on certain platforms that the ILEO has been verified to work.
This includes,
    1. the platform must be a hybrid platform (via CPUID)
    2. the platform must be a mobile platform (via ACPI)
    3. the platform must be in an allowed list (via CPU model)
But this also blocks users who want to experience it on the platforms that don't meet all these criteria.
Introduce parameter "--ignore-platform-check" to ignore such checks.