### PR TITLE
Tolerant /proc/stat parsing failure

### DIFF
--- a/src/lpmd_util.c
+++ b/src/lpmd_util.c
@@ -169,7 +169,9 @@ static int parse_proc_stat(void)
 				continue;
 			}
 
-			sscanf (p, "%llu", &info->stat[idx]);
+			if (sscanf (p, "%llu", &info->stat[idx]) <= 0)
+				lpmd_log_debug("Failed to parse /proc/stat, defer update in next snapshot.");
+
 			p = strtok (NULL, " ");
 			idx++;
 		}


### PR DESCRIPTION
When parsing some columns in /proc/stat fails, ignore the failure. This may cause bogus utilization because it is not a critical falure and things will be back to work when /proc/stat is parsed successfully.

Add a debug message for this case.

This address issue https://github.com/intel/intel-lpmd/issues/52