### PR TITLE
intel_lpmd: intel_lpmd 0.0.7 release

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -1,7 +1,7 @@
 AC_PREREQ(1.0)
 
 m4_define([lpmd_major_version], [0])
-m4_define([lpmd_minor_version], [0.6])
+m4_define([lpmd_minor_version], [0.7])
 m4_define([lpmd_version],
           [lpmd_major_version.lpmd_minor_version])
 


### PR DESCRIPTION
This release

- Change lpmd description from "Low Power Mode Daemon" to "Energy Optimizer (lpmd)" because it covers more scenarios.

- Fix invalid cgroup setting during probe, in case lpmd doesn't quit smoothly and cleanups are not done properly, in the previous run.

- Introduce a new parameter "--ignore-platform-check". With it, the platform check is skipped so lpmd can be launched on unvalidated platforms.

- Provide more detailed information when lpmd failed to probe on an unvalidated platform.

- Various of fixes for array bound check, potential memory leak, etc.

- Autotool improvements.