### PR TITLE
Fix file descriptor resource leaks on error return paths

### DIFF
--- a/src/lpmd_util.c
+++ b/src/lpmd_util.c
@@ -109,14 +109,17 @@ static int parse_proc_stat(void)
 	if (!proc_stat_prev)
 		proc_stat_prev = calloc(sizeof(struct proc_stat_info), count);
 
-	if (!proc_stat_prev)
+	if (!proc_stat_prev) {
+		fclose (filep);
 		return 1;
+	}
 
 	if (!proc_stat_cur)
 		proc_stat_cur = calloc(sizeof(struct proc_stat_info), count);
 
 	if (!proc_stat_cur) {
 		free(proc_stat_prev);
+		fclose (filep);
 		proc_stat_prev = NULL;
 		return 1;
 	}


### PR DESCRIPTION
Fix a couple of resource leaks on error return paths by closing the opened file.

Fixes: 024706f244ad ("Check for calloc failure")