### PR TITLE
Manual: Fix grammar mistake found with debian lintian tool

### DIFF
--- a/man/intel_lpmd_config.xml.5
+++ b/man/intel_lpmd_config.xml.5
@@ -130,7 +130,7 @@ switching. This flag is not used when configuration uses "State" based
 configuration, where this flag can be defined per state.
 .PP
 .B States
-Allows to define per platform low power states. Each state defines
+Allows one to define per platform low power states. Each state defines
 has an entry condition and set of parameters to use.
 
 .SH State Definition


### PR DESCRIPTION
The phrase "Allows to" should be "Allows one to", fix it.