### PR TITLE
Drop unused variables and functions

### DIFF
--- a/src/lpmd_util.c
+++ b/src/lpmd_util.c
@@ -83,7 +83,6 @@ static int probe_gfx_util_sysfs(void)
 {
 	FILE *fp;
 	char buf[8];
-	bool gt0_is_gt;
 
 	if (access("/sys/class/drm/card0/device/tile0/gt0/gtidle/idle_residency_ms", R_OK))
 		return 1;
@@ -119,11 +118,9 @@ static int get_gfx_util_sysfs(unsigned long long time_ms)
 {
 	static unsigned long long gfx_rc6_prev = ULLONG_MAX, sam_mc6_prev = ULLONG_MAX;
 	unsigned long long gfx_rc6, sam_mc6;
-	unsigned long long val;
 	FILE *fp;
 	int gfx_util, sam_util;
 	int ret;
-	int i;
 
 	gfx_util = sam_util = -1;
 

--- a/src/wlt_proxy/state_manager.c
+++ b/src/wlt_proxy/state_manager.c
@@ -285,6 +285,8 @@ int staytime_to_staycount(enum state_idx state)
         case PERF_MODE:
             stay_count = (int)PERF_MODE_STAY/get_poll_ms(PERF_MODE);
             break;
+	default:
+	    break;
     }
     return stay_count;
 }

--- a/src/wlt_proxy/state_util.c
+++ b/src/wlt_proxy/state_util.c
@@ -381,10 +381,9 @@ static int read_aperf_mperf_tsc_perf(struct thread_data *t, int cpu) {
 /*Calc perf [cpu utilization per core] difference from MSR registers */
 int update_perf_diffs(float *sum_norm_perf, int stat_init_only) {
 
-    int fd, maxed_cpu = -1;
+    int maxed_cpu = -1;
     float min_load = 100.0, min_s0 = 1.0, next_s0 = 1.0;
     float max_load = 0, max_2nd_load = 0, max_3rd_load = 0, next_load = 0;
-    uint64_t aperf_raw, mperf_raw, pperf_raw, tsc_raw, poll_cpu_us = 0;
     int t, min_s0_cpu = 0, first_pass = 1;
 
     for (t = 0; t < get_max_online_cpu(); t++) {

--- a/src/wlt_proxy/state_util.c
+++ b/src/wlt_proxy/state_util.c
@@ -269,14 +269,6 @@ static unsigned int read_mperf_config(void) {
 }
 
 /*helper - pperf reading */
-static unsigned int read_tsc_config(void) {
-    const char *const path = "/sys/bus/event_source/devices/msr/events/tsc";
-    const char *const format = "event=%x";
-
-    return read_perf_counter_info_n(path, format);
-}
-
-/*helper - pperf reading */
 static unsigned int read_msr_type(void) {
     const char *const path = "/sys/bus/event_source/devices/msr/type";
     const char *const format = "%u";


### PR DESCRIPTION
Drop unused variables and functions. They caused compile errors when updating the RHEL packages.