### PR TITLE
Fix the errors, including unused variable, function, unused tag, and invalid assignment

### DIFF
--- a/src/lpmd_cgroup.c
+++ b/src/lpmd_cgroup.c
@@ -211,8 +211,6 @@ int cgroup_init(lpmd_config_t *config)
 
 int process_cgroup(lpmd_config_state_t *state, enum lpm_cpu_process_mode mode)
 {
-	int ret;
-
 	if (state->cpumask_idx == CPUMASK_NONE) {
 		lpmd_log_debug ("Ignore cgroup processing\n");
 		return 0;

--- a/src/lpmd_cpu.c
+++ b/src/lpmd_cpu.c
@@ -455,7 +455,7 @@ err:
 int detect_lpm_cpus(char *cmd_cpus)
 {
 	int ret;
-	char *str;
+	char *str = NULL;
 
 	if (cmd_cpus && cmd_cpus[0] != '\0') {
 		ret = detect_lpm_cpus_cmd (cmd_cpus);

--- a/src/lpmd_dbus_server.c
+++ b/src/lpmd_dbus_server.c
@@ -51,13 +51,6 @@ static gboolean
 dbus_interface_l_pm__au_to(PrefObject *obj, GError **error);
 
 static gboolean
-dbus_interface_s_uv__mo_de__en_te_r(PrefObject *obj, GError **error);
-
-static gboolean
-dbus_interface_s_uv__mo_de__ex_it(PrefObject *obj, GError **error);
-
-
-static gboolean
 (*intel_lpmd_dbus_exit_callback)(void);
 
 // Dbus object initialization

--- a/src/lpmd_hfi.c
+++ b/src/lpmd_hfi.c
@@ -206,7 +206,6 @@ static char *update_one_cpu(struct perf_cap *perf_cap)
 
 static void process_one_event(int first, int last, int nr)
 {
-	lpmd_config_t *config = get_lpmd_config();
 
 	/* Need to update more CPUs */
 	if (nr == 16 && last != get_max_online_cpu ())

--- a/src/lpmd_irq.c
+++ b/src/lpmd_irq.c
@@ -63,9 +63,6 @@ struct info_irqs {
 struct info_irqs info_irqs;
 struct info_irqs *info = &info_irqs;
 
-static char *irq_str;
-static int lp_mode_irq;
-
 
 /* Interrupt Management */
 #define SOCKET_PATH "irqbalance"

--- a/src/lpmd_misc.c
+++ b/src/lpmd_misc.c
@@ -25,7 +25,6 @@
 
 static int has_itmt;
 static int saved_itmt = SETTING_IGNORE;
-static int lp_mode_itmt = SETTING_IGNORE;
 
 int get_itmt(void)
 {

--- a/src/lpmd_state_machine.c
+++ b/src/lpmd_state_machine.c
@@ -57,13 +57,13 @@ int update_lpmd_state(int new)
 				break;
 			lpmd_log_debug ("Freeze lpmd\n");
 			saved_lpmd_state = lpmd_state;
-			lpmd_state == LPMD_FREEZE;
+			lpmd_state = LPMD_FREEZE;
 			break;
 		case LPMD_RESTORE:
 			if (lpmd_state != LPMD_FREEZE)
 				break;
 			lpmd_log_debug ("Restore lpmd\n");
-			lpmd_state == saved_lpmd_state;
+			lpmd_state = saved_lpmd_state;
 			saved_lpmd_state = lpmd_state;
 			break;
 		default:

--- a/src/lpmd_state_machine.c
+++ b/src/lpmd_state_machine.c
@@ -324,23 +324,26 @@ static void dump_data(lpmd_config_t *config, int idx)
 	if (config->wlt_hint_enable)
 		offset += snprintf(buf + offset , MAX_STR_LENGTH - offset, "WLT [%2d] ", config->data.wlt_hint);
 
-	if (config->util_sys_enable)
+	if (config->util_sys_enable) {
 		if (config->data.util_sys == -1)
 			offset += snprintf(buf + offset , MAX_STR_LENGTH - offset, "SYS [   N/A] ");
 		else
 			offset += snprintf(buf + offset , MAX_STR_LENGTH - offset, "SYS [%3d.%02d] ", config->data.util_sys / 100, config->data.util_sys % 100);
+	}
 
-	if (config->util_cpu_enable)
+	if (config->util_cpu_enable) {
 		if (config->data.util_cpu == -1)
 			offset += snprintf(buf + offset , MAX_STR_LENGTH - offset, "CPU [   N/A] ");
 		else
 			offset += snprintf(buf + offset , MAX_STR_LENGTH - offset, "CPU [%3d.%02d] ", config->data.util_cpu / 100, config->data.util_cpu % 100);
+	}
 
-	if (config->util_gfx_enable)
+	if (config->util_gfx_enable) {
 		if (config->data.util_gfx == -1)
 			offset += snprintf(buf + offset , MAX_STR_LENGTH - offset, "GFX [   N/A] ");
 		else
 			offset += snprintf(buf + offset , MAX_STR_LENGTH - offset, "GFX [%3d.%02d] ", config->data.util_gfx / 100, config->data.util_gfx % 100);
+	}
 
 	if (state->cpumask_idx != CPUMASK_NONE)
 		offset += snprintf(buf + offset , MAX_STR_LENGTH - offset, "CPUMASK [%s] ", get_cpus_hexstr(state->cpumask_idx));

--- a/src/lpmd_state_machine.c
+++ b/src/lpmd_state_machine.c
@@ -628,7 +628,7 @@ static int build_state_cpumask(lpmd_config_state_t *state)
 int lpmd_build_config_states(lpmd_config_t *lpmd_config)
 {
 	lpmd_config_state_t *state;
-	int i, ret;
+	int i;
 
 	build_default_states(lpmd_config);
 

--- a/src/lpmd_state_machine.c
+++ b/src/lpmd_state_machine.c
@@ -305,7 +305,6 @@ static int enter_state(lpmd_config_t *config, int idx)
 
 	process_cgroup(state, config->mode);
 
-end:
 	return 0;
 }
 

--- a/src/lpmd_util.c
+++ b/src/lpmd_util.c
@@ -40,7 +40,6 @@
 
 #define PATH_PROC_STAT "/proc/stat"
 
-static int current_idx = STATE_NONE;
 
 enum type_stat {
 	STAT_CPU,


### PR DESCRIPTION
Hi,

The PR fixed the compile errors when applying `-Wall`.
One uninitialized variable was found as described in https://github.com/intel/intel-lpmd/issues/102 needs to be resolved.
Moreover, the commit shown as follows needs your review and verification.

[lpmd_state_machine: Fix incorrect assignment](https://github.com/smallorange/intel-lpmd/commit/a9a0840bba2d4588b1558a56f3c7052d182d01aa)
```
lpmd_state_machine: Fix incorrect assignment
lpmd_state == LPMD_FREEZE; should be lpmd_state = LPMD_FREEZE;
and
lpmd_state == saved_lpmd_state; should be lpmd_state = saved_lpmd_state;
```

Thank you :)