### PR TITLE
Add GetState D-Bus method to query current LPM control mode

### DIFF
--- a/src/intel_lpmd_dbus_interface.xml
+++ b/src/intel_lpmd_dbus_interface.xml
@@ -19,5 +19,9 @@
 		<method name="LPM_AUTO">
 		</method>
 
+		<method name="GetState">
+			<arg type="s" name="state" direction="out"/>
+		</method>
+
 	</interface>
 </node>

--- a/src/lpmd_dbus_server.c
+++ b/src/lpmd_dbus_server.c
@@ -155,6 +155,23 @@ lpmd_dbus_handle_method_call(GDBusConnection       *connection,
 		return;
 	}
 
+	if (g_strcmp0(method_name, "GetState") == 0) {
+		const char *state_names[] = {
+			[LPMD_OFF] = "OFF",
+			[LPMD_ON] = "ON",
+			[LPMD_AUTO] = "AUTO",
+			[LPMD_FREEZE] = "FREEZE",
+			[LPMD_RESTORE] = "RESTORE",
+			[LPMD_TERMINATE] = "TERMINATE",
+		};
+		int state = get_lpmd_state();
+		const char *name = (state >= 0 && state <= LPMD_TERMINATE) ? state_names[state] : "UNKNOWN";
+
+		g_dbus_method_invocation_return_value(invocation,
+						     g_variant_new("(s)", name));
+		return;
+	}
+
 	g_set_error(&error,
 		    G_DBUS_ERROR,
 		    G_DBUS_ERROR_UNKNOWN_METHOD,

--- a/tools/intel_lpmd_control.c
+++ b/tools/intel_lpmd_control.c
@@ -51,8 +51,40 @@ main(int argc, char **argv)
 	if (argc < 2) {
 		fprintf (stderr, "intel_lpmd_control: missing control command\n");
 		fprintf (stderr, "syntax:\n");
-		fprintf (stderr, "intel_lpmd_control ON|OFF|AUTO\n");
+		fprintf (stderr, "intel_lpmd_control ON|OFF|AUTO|STATUS\n");
 		exit (0);
+	}
+
+	connection = g_bus_get_sync(G_BUS_TYPE_SYSTEM, NULL, &error);
+	if (connection == NULL)
+		return FALSE;
+
+	if (!strncmp (argv[1], "STATUS", 6)) {
+		g_autoptr(GVariant) result = NULL;
+
+		result = g_dbus_connection_call_sync (connection,
+						      INTEL_LPMD_SERVICE_NAME,
+						      INTEL_LPMD_SERVICE_OBJECT_PATH,
+						      INTEL_LPMD_SERVICE_INTERFACE,
+						      "GetState",
+						      NULL,
+						      G_VARIANT_TYPE ("(s)"),
+						      G_DBUS_CALL_FLAGS_NONE,
+						      -1,
+						      NULL,
+						      &error);
+
+		if (error != NULL) {
+			g_warning ("Fail on connecting lpmd: %s", error->message);
+			exit (1);
+		}
+
+		const gchar *state;
+
+		g_variant_get (result, "(&s)", &state);
+		g_print ("%s\n", state);
+
+		return 0;
 	}
 
 	if (!strncmp (argv[1], "ON", 2))
@@ -65,10 +97,6 @@ main(int argc, char **argv)
 		g_warning ("intel_lpmd_control: Invalid command");
 		exit (1);
 	}
-
-	connection = g_bus_get_sync(G_BUS_TYPE_SYSTEM, NULL, &error);
-	if (connection == NULL)
-		return FALSE;
 
 	g_dbus_connection_call_sync (connection,
 				     INTEL_LPMD_SERVICE_NAME,


### PR DESCRIPTION
Currently its not possible to get the current state of intel-lpmd. Add "STATUS" for intel_lpmd_control to find out the current status via dbus.