### PR TITLE
Multiple fixes and man page update

### DIFF
--- a/README.md
+++ b/README.md
@@ -7,7 +7,13 @@ the system into Low Power Mode by activating the power-efficient CPUs and
 disabling the rest, and restores the system from Low Power Mode by activating
 all CPUs.
 
-## Usage
+## Before You Start
+
+**Please note** that the installed configuration files serve as templates of
+best practices for specific platform models and disable lpmd by default. For
+LPMD to start the user is expected to either edit the main
+"intel_lpmd_config.xml" config file or after starting the program, enable LPMD
+by using the intel_lpmd_control tool.
 
 Refer to the man pages for command line arguments and XML configurations:
 

--- a/README.md
+++ b/README.md
@@ -1,6 +1,11 @@
 # Intel Low Power Mode Daemon
 
-Intel Low Power Mode Daemon (lpmd) is a Linux daemon designed to optimize active idle power. It selects the most power-efficient CPUs based on a configuration file or CPU topology. Depending on system utilization and other hints, it puts the system into Low Power Mode by activating the power-efficient CPUs and disabling the rest, and restores the system from Low Power Mode by activating all CPUs.
+Intel Low Power Mode Daemon (lpmd) is a Linux daemon designed to optimize active
+idle power. It selects the most power-efficient CPUs based on a configuration
+file or CPU topology. Depending on system utilization and other hints, it puts
+the system into Low Power Mode by activating the power-efficient CPUs and
+disabling the rest, and restores the system from Low Power Mode by activating
+all CPUs.
 
 ## Usage
 
@@ -40,10 +45,13 @@ make
 sudo make install
 ```
 
-The generated artifacts are copied to respective directories under `/usr/local`. If a custom install path is preferred other than system default,  make sure `--localstatedir` and `--sysconfdir` are set to the right path that the system can understand. If installed via RPM then artifacts would be under `/usr`.
+The generated artifacts are copied to respective directories under `/usr/local`.
+If a custom install path is preferred other than system default,  make sure
+`--localstatedir` and `--sysconfdir` are set to the right path that the system
+can understand. If installed via RPM then artifacts would be under `/usr`.
 
-Example command for installation using prefix under `/opt/lpmd_install` dir with `--localstatedir` and `--sysconfdir` set to system default
-
+Example command for installation using prefix under `/opt/lpmd_install` dir with
+`--localstatedir` and `--sysconfdir` set to system default
 
 ```sh
 ./autogen.sh prefix=/opt/lpmd_install --localstatedir=/var --sysconfdir=/etc
@@ -87,8 +95,8 @@ Start `lpmd` using:
 sudo sh tests/lpm_test_interface.sh 4
 ```
 
-Run a workload and monitor `lpmd` to ensure it puts the system in the appropriate state based on the load.
-
+Run a workload and monitor `lpmd` to ensure it puts the system in the
+appropriate state based on the load.
 
 ## Releases
 

--- a/data/intel_lpmd_config_F6_M204.xml
+++ b/data/intel_lpmd_config_F6_M204.xml
@@ -146,19 +146,19 @@ for Intel Energy Optimizer (LPMD) daemon
 			<ID> 1 </ID>
 			<Name> UTIL_IDLE </Name>
 			<WLTType> 1 </WLTType>
-			<ActiveCPUs>16-19</ActiveCPUs>
+			<ActiveCPUs>12-15</ActiveCPUs>
 		</State>
 		<State>
 			<ID> 2 </ID>
 			<Name> UTIL_IDLE_SUSTAIN </Name>
 			<WLTType> 2 </WLTType>
-			<ActiveCPUs>0-19</ActiveCPUs>
+			<ActiveCPUs>0-15</ActiveCPUs>
 		</State>
 		<State>
 			<ID> 3 </ID>
 			<Name> UTIL_IDLE_BURSTY </Name>
 			<WLTType> 3 </WLTType>
-			<ActiveCPUs>0-19</ActiveCPUs>
+			<ActiveCPUs>0-15</ActiveCPUs>
 		</State>
 	</States>
 

--- a/man/intel_lpmd.8
+++ b/man/intel_lpmd.8
@@ -21,7 +21,7 @@
 .\"
 .\" Copyright (C) 2012 Intel Corporation. All rights reserved.
 .\"
-.TH intel_lpmd "8" "1 Jun 2023"
+.TH intel_lpmd "8" "08 Apr 2026"
 
 .SH NAME
 intel_lpmd \- Intel Energy Optimizer (LPMD) Daemon
@@ -31,25 +31,24 @@ intel_lpmd \- Intel Energy Optimizer (LPMD) Daemon
 
 .SH DESCRIPTION
 .B intel_lpmd
-is a Linux daemon used for energy optimization on Intel hybrid systems.
-This daemon uses a configuration file "intel_lpmd_config.xml".
-Based on the configuration, it will choose right set of CPUs
-to enable. For example, this daemon can monitor system utilization
-and choose a set of low power CPUs to enable and disable the rest.
-This enable disable of CPUs are done using Linux cpuset feature
-of intel power clamp driver.
+is a Linux daemon used for energy optimization on Intel hybrid systems. This
+daemon uses a configuration file called "intel_lpmd_config.xml". The other
+installed configuration files are to be treated as best practice templates. The
+main configuration file should be edited by the user to enable LPMD and it's
+desired functionalities. Based on the configuration and system utilization LPMD
+can:
 
-There is a control utility distributed along with this daemon.
-This control utility is called "intel_lpmd_control". This utility
-can be used to set different modes for this daemon.
-For example:
-intel_lpmd_control ON
-	To turn on low power mode operation.
-intel_lpmd_control OFF
-	To turn off low power mode operation.
-intel_lpmd_control AUTO
-	To turn on low power mode operation in auto mode, which
-	allows low power mode based on system utilization.
+- choose the best set of CPU cores to enable for a given moment in time
+
+- choose the best EPP (energe performance preference) and EPB (energy
+performance bias) value
+
+- pick the best SoC power slider settings
+
+There is a control utility distributed along with this daemon. It's called
+"intel_lpmd_control" and it can be used to change modes in the running LPMD
+instance.
+
 .SH OPTIONS
 .TP
 .B -h --help
@@ -88,8 +87,13 @@ Run intel_lpmd with log directed to stdout
 .B intel_lpmd --systemd --dbus-enable
 Run intel_lpmd as a service with logs directed to system journal
 
+.TP
+.B sudo systemctl enable intel_lpmd.service --now
+Enable and run intel_lpmd as a systemd service that's persistent after system
+reboot.
+
 .SH SEE ALSO
-intel_lpmd_config.xml(5)
+intel_lpmd_config.xml(5), intel_lpmd_control(8)
 
 .SH AUTHOR
 Written by Zhang Rui <rui.zhang@intel.com>

--- a/man/intel_lpmd_config.xml.5
+++ b/man/intel_lpmd_config.xml.5
@@ -86,40 +86,12 @@ specifies the system utilization threshold for entering Low Power Mode.
 The system workload is considered to fit the lp_mode_cpus capacity when system
 utilization is under this threshold.
 Setting to 0 or leaving this empty disables the utilization monitor.
-
 .PP
 .B util_exit_threshold
 specifies the CPU utilization threshold for exiting Low Power Mode.
 The system workload is considered to not fit the lp_mode_cpus capacity when
 the utilization of the busiest lp_mode_cpus is above this threshold.
 Setting to 0 or leaving this empty disables the utilization monitor.
-.PP
-.B EntryDelayMS
-specifies the sample interval used by the utilization Monitor when system
-wants to enter Low Power Mode based on system utilization.
-Setting to 0 or leaving this empty will cause the utilization Monitor to use
-the default interval, 1000 milli seconds.
-.PP
-.B ExitDelayMS
-specifies the sample interval used by the utilization Monitor when system
-wants to exit Low Power Mode based on CPU utilization.
-Setting to 0 or leaving this empty will cause the utilization Monitor to use
-the adaptive value. The adaptive interval is based on CPU utilization.
-The busier the CPU is, the shorter interval the utilization monitor uses.
-.PP
-.B EntryHystMS
-specifies a hysteresis threshold when system is in Low Power Mode.
-If set, when the previous average time stayed in Low Power Mode is lower than
-this value, the current enter Low Power Mode request will be ignored because
-it is expected that the system will exit Low Power Mode soon.
-Setting to 0 or leaving this empty disables this hysteresis algorithm.
-.PP
-.B ExitHystMS
-specifies a hysteresis threshold when system is not in Low Power Mode.
-If set, when the previous average time stayed out of Low-Power-Mode is lower
-than this value, the current exit Low Power Mode request will be ignored
-because it is expected that the system will enter Low Power Mode soon.
-Setting to 0 or leaving this empty disables this hysteresis algorithm.
 .PP
 .B IgnoreITMT
 Avoid changing scheduler ITMT flag. This means that during transition to
@@ -273,30 +245,6 @@ The configuration file format conforms to XML specifications.
 	<util_exit_threshold>Example threshold</util_exit_threshold>
 
 	<!--
-		Entry delay. Minimum delay in non Low Power mode to
-		enter LPM mode.
-	-->
-	<EntryDelayMS>Example delay</EntryDelayMS>
-
-	<!--
-		Exit delay. Minimum delay in Low Power mode to
-		exit LPM mode.
-	-->
-	<ExitDelayMS>Example delay</ExitDelayMS>
-
-	<!--
-		Lowest hyst average in-LP-mode time in msec to enter LP mode
-		0: to disable hyst support
-	-->
-	<EntryHystMS>Example hyst</EntryHystMS>
-
-	<!--
-		Lowest hyst average out-of-LP-mode time in msec to exit LP mode
-		0: to disable hyst support
-	-->
-	<ExitHystMS>Example hyst</ExitHystMS>
-
-	<!--
 		EPP to use in Low Power Mode
 		0-255: Valid EPP value to use in Low Power Mode
 		   -1: Don't change EPP in Low Power Mode
@@ -323,14 +271,6 @@ util_entry_threshold: 0. Disable utilization monitor.
 .IP \(bu 2
 util_exit_threshold: 0. Disable utilization monitor.
 .IP \(bu 2
-EntryDelayMS: 0. Do not take effect when utilization monitor is disabled.
-.IP \(bu 2
-ExitDelayMS: 0. Do not take effect when utilization monitor is disabled.
-.IP \(bu 2
-EntryHystMS: 0. Do not take effect when utilization monitor is disabled.
-.IP \(bu 2
-ExitHystMS: 0. Do not take effect when utilization monitor is disabled.
-.IP \(bu 2
 lp_mode_epp: -1. Do not change EPP when entering Low Power Mode.
 
 .sp 1
@@ -343,10 +283,6 @@ lp_mode_epp: -1. Do not change EPP when entering Low Power Mode.
 	<HfiSuvEnable>0</HfiSuvEnable>
 	<util_entry_threshold>0</util_entry_threshold>
 	<util_exit_threshold>0</util_exit_threshold>
-	<EntryDelayMS>0</EntryDelayMS>
-	<ExitDelayMS>0</ExitDelayMS>
-	<EntryHystMS>0</EntryHystMS>
-	<ExitHystMS>0</ExitHystMS>
 	<lp_mode_epp>-1</lp_mode_epp>
 </Configuration>
 .PP
@@ -365,14 +301,6 @@ util_entry_threshold: 5. Enter Low Power Mode when system utilization is lower t
 .IP \(bu 2
 util_exit_threshold: 95. Exit Low Power Mode when the utilization of any of the lp_mode_cpus is higher than 95%.
 .IP \(bu 2
-EntryDelayMS: 0. Resample every 1000ms when system is out of Low Power Mode.
-.IP \(bu 2
-ExitDelayMS: 0. Resample adaptively based on the utilization of lp_mode_cpus when system is in Low Power Mode.
-.IP \(bu 2
-EntryHystMS: 2000. Ignore the current Enter Low Power Mode request when the previous average time stayed in Low Power Mode is lower than 2000ms.
-.IP \(bu 2
-ExitHystMS: 3000. Ignore the current Exit Low Power Mode request when the previous average time stayed out of Low Power Mode is lower than 3000ms.
-.IP \(bu 2
 lp_mode_epp: -1. Do not change EPP when entering Low Power Mode.
 
 .sp 1
@@ -385,10 +313,38 @@ lp_mode_epp: -1. Do not change EPP when entering Low Power Mode.
 	<HfiSuvEnable>1</HfiSuvEnable>
 	<util_entry_threshold>5</util_entry_threshold>
 	<util_exit_threshold>95</util_exit_threshold>
-	<EntryDelayMS>0</EntryDelayMS>
-	<ExitDelayMS>0</ExitDelayMS>
-	<EntryHystMS>2000</EntryHystMS>
-	<ExitHystMS>3000</ExitHystMS>
 	<lp_mode_epp>-1</lp_mode_epp>
 </Configuration>
 .EE
+
+.SH Currently unimplemented options
+.PP
+.B EntryDelayMS
+specifies the sample interval used by the utilization Monitor when system
+wants to enter Low Power Mode based on system utilization.
+Setting to 0 or leaving this empty will cause the utilization Monitor to use
+the default interval, 1000 milli seconds.
+.PP
+.B ExitDelayMS
+specifies the sample interval used by the utilization Monitor when system
+wants to exit Low Power Mode based on CPU utilization.
+Setting to 0 or leaving this empty will cause the utilization Monitor to use
+the adaptive value. The adaptive interval is based on CPU utilization.
+The busier the CPU is, the shorter interval the utilization monitor uses.
+.PP
+.B EntryHystMS
+specifies a hysteresis threshold when system is in Low Power Mode.
+If set, when the previous average time stayed in Low Power Mode is lower than
+this value, the current enter Low Power Mode request will be ignored because
+it is expected that the system will exit Low Power Mode soon.
+Setting to 0 or leaving this empty disables this hysteresis algorithm.
+.PP
+.B ExitHystMS
+specifies a hysteresis threshold when system is not in Low Power Mode.
+If set, when the previous average time stayed out of Low-Power-Mode is lower
+than this value, the current exit Low Power Mode request will be ignored
+because it is expected that the system will enter Low Power Mode soon.
+Setting to 0 or leaving this empty disables this hysteresis algorithm.
+
+.SH SEE ALSO
+intel_lpmd(8), intel_lpmd_control(8)

--- a/man/intel_lpmd_config.xml.5
+++ b/man/intel_lpmd_config.xml.5
@@ -21,7 +21,7 @@
 .\"
 .\" Copyright (C) 2012 Intel Corporation. All rights reserved.
 .\"
-.TH intel_lpmd_config.xml "5" "1 Jun 2023"
+.TH intel_lpmd_config.xml "5" "8 Apr 2026"
 
 .SH NAME
 intel_lpmd_config.xml \- Configuration file for intel_lpmd
@@ -30,18 +30,22 @@ $(TDCONFDIR)/etc/intel_lpmd/intel_lpmd_config.xml
 
 .SH DESCRIPTION
 .B intel_lpmd_config.xml
-is a configuration file for the Intel Low Power Mode Daemon.
-It is used to describe the lp_mode_cpus to use in Low Power Mode,
-as well as the way to restrict work to those CPUs. It also describes
-if and how the HFI monitor and utilization monitor works. The location
-of this file depends on the configuration option used during build time.
+is a configuration file for the Intel Low Power Mode Daemon. It's used to
+describe states and rules of switching between the states. These states are
+custom, user defined sets of parameters that the platform should use for optimal
+performance and energy saving. The rules of switching refer to what system
+information dictates whether a change of state is needed or not. It can be
+either information from a hardware source or software calculated if the hardware
+features are not supported.
+
 .PP
 .B lp_mode_cpus
-is a set of active CPUs when system is in Low Power Mode.
-This usually equals a group of most power efficient CPUs on a platform to
-achieve best power saving. When not specified, intel_lpmd tool can detect this
-automatically. E.g. it uses an E-core Module on Intel Alderlake platform, and
-it uses the Low Power E-cores on SoC Die on Intel Meteorlake platform.
+is a set of active CPUs when system is in Low Power Mode. This usually equals a
+group of most power efficient CPUs on a platform to achieve best power saving.
+When not specified, intel_lpmd tool can detect this automatically. E.g. it uses
+L-cores on Intel PantherLake platform, the E-core Module on Intel Alderlake
+platform, and it uses the Low Power E-cores on SoC Die on Intel Meteorlake
+platform.
 .PP
 .B Mode
 specifies the way to migrate the tasks to the lp_mode_cpus.
@@ -56,20 +60,14 @@ lp_mode_cpus only.
 Mode 2: Force idle injection to the non-lp_mode_cpus and leverage the
 scheduler to schedule the other tasks to the lp_mode_cpus.
 .PP
-.B PerformanceDef
-specifies the default behavior when power setting is set to Performance.
+.B PerformanceDef / BalancedDef / PowersaverDef
+specifies the default behavior for a given power profile.
 .IP \(bu 2
 -1 : Never enter Low Power Mode.
 .IP \(bu 2
 0 : opportunistic Low Power Mode enter/exit based on HFI/Utilization request.
 .IP \(bu 2
 1 : Always stay in Low Power Mode.
-.PP
-.B BalancedDef
-specifies the default behavior when power setting is set to Balanced.
-.PP
-.B PowersaverDef
-specifies the default behavior when power setting is set to Power saver.
 .PP
 .B HfiLpmEnable
 specifies if the HFI monitor can capture the HFI hints for Low Power Mode.
@@ -127,16 +125,18 @@ Setting to 0 or leaving this empty disables this hysteresis algorithm.
 Avoid changing scheduler ITMT flag. This means that during transition to
 low power mode, ITMT flag is not changed. This reduces latency during
 switching. This flag is not used when configuration uses "State" based
-configuration, where this flag can be defined per state.
+configuration, where this flag can be defined per state. ITMT is only relevant
+for platforms before MTL and the debugfs file is not present on later
+platforms.
 .PP
 .B States
 Allows one to define per platform low power states. Each state defines
 has an entry condition and set of parameters to use.
 
 .SH State Definition
-There can be multiple State configuration can be present. Each
-configuration is valid for a platform. A State header defines parameters,
-which are used to match a platform.
+There can be multiple state configurations present. Each configuration is valid
+for a platform. A state header defines parameters, which are used to match a
+platform.
 .B CPUFamily
 CPU generation to match.
 .PP
@@ -160,7 +160,7 @@ A name for the state.
 .PP
 .B EntrySystemLoadThres
 System Entry load threshold in percent. System utilization is different
-based on the number of CPUs are active in a configuration. This value
+based on the number of active CPUs in a configuration. This value
 is calculated from /proc/stat sysfs. To enter into this state, the
 system utilization must be less or equal to this value.
 .PP
@@ -186,13 +186,14 @@ EPP to apply for this state. -1 to ignore.
 EPB to apply for this state. -1 to ignore.
 .PP
 .B ITMTState
-Set the state of ITMT flag. -1 to ignore.
+Set the state of ITMT flag. -1 to ignore. ITMT is only relevant for platforms
+before MTL and the debugfs file is not present on later platforms.
 .PP
 .B IRQMigrate
 Migrate IRQs to the active CPUs in this state. -1 to ignore.
 .PP
 .B MinPollInterval
-Minimum polling interval in milli seconds.
+Minimum polling interval in milliseconds.
 .PP
 .B MaxPollInterval
 Maximum polling interval in milli seconds. This is optional,

--- a/man/intel_lpmd_control.8
+++ b/man/intel_lpmd_control.8
@@ -21,7 +21,7 @@
 .\"
 .\" Copyright (C) 2025 Intel Corporation. All rights reserved.
 .\"
-.TH intel_lpmd_control "8" "7 Mar 2025"
+.TH intel_lpmd_control "8" "8 Apr 2026"
 
 .SH NAME
 intel_lpmd_control \- Control utility for the Intel Low Power Mode Daemon (LPMD)
@@ -31,7 +31,9 @@ intel_lpmd_control \- Control utility for the Intel Low Power Mode Daemon (LPMD)
 
 .SH DESCRIPTION
 .B intel_lpmd_control
-is a command-line utility used to control the Intel Low Power Mode Daemon (LPMD). It allows users to enable, disable, or set the daemon to automatic mode based on system utilization.
+is a command-line utility used to control the Intel Low Power Mode Daemon
+(LPMD). It allows users to enable, disable, or set the daemon to automatic mode
+based on system utilization.
 
 .SH OPTIONS
 .TP
@@ -42,7 +44,8 @@ Enables low power mode operation.
 Disables low power mode operation.
 .TP
 .B AUTO
-Enables low power mode operation in automatic mode, allowing system utilization to determine low power state activation.
+Enables operation in automatic mode, allowing system utilization to determine
+low power state activation.
 
 .SH EXAMPLES
 .TP
@@ -56,7 +59,7 @@ Turns off low power mode operation.
 Turns on low power mode operation in automatic mode.
 
 .SH SEE ALSO
-.B intel_lpmd(8)
+.B intel_lpmd_config.xml(5), intel_lpmd(8)
 
 .SH AUTHOR
 Written by Deepak Sundar <deepak.sundar@intel.com>

--- a/src/include/lpmd.h
+++ b/src/include/lpmd.h
@@ -284,6 +284,8 @@ enum power_profile_daemon_mode {
 	PPD_INVALID
 };
 
+#define DEF_POLLING_INTERVAL	100
+
 /* lpmd_main.c */
 int in_debug_mode(void);
 int do_platform_check(void);

--- a/src/include/lpmd.h
+++ b/src/include/lpmd.h
@@ -410,6 +410,8 @@ int lpmd_write_str_append(const char *name, char *str, int print_level);
 int lpmd_write_int(const char *name, int val, int print_level);
 int lpmd_open(const char *name, int print_level);
 int lpmd_read_int(const char *name, int *val, int print_level);
+int lpmd_read_yn(const char *name, int *val, int print_level);
+int lpmd_write_yn(const char *name, int val, int print_level);
 char* get_time(void);
 void time_start(void);
 char* time_delta(void);

--- a/src/lpmd_cgroup.c
+++ b/src/lpmd_cgroup.c
@@ -177,9 +177,11 @@ static int process_cpu_isolate(lpmd_config_state_t *state)
 		return 1;
 
 	if (!cpumask_equal(state->cpumask_idx, CPUMASK_ONLINE)) {
-		if (lpmd_write_str ("/sys/fs/cgroup/lpm/cpuset.cpus", get_cpu_isolation_str(state->cpumask_idx), LPMD_LOG_DEBUG))
+		if (lpmd_write_str ("/sys/fs/cgroup/lpm/cpuset.cpus.exclusive", get_cpu_isolation_str(state->cpumask_idx), LPMD_LOG_DEBUG))
 			return 1;
 		if (lpmd_write_str ("/sys/fs/cgroup/lpm/cpuset.cpus.partition", "isolated", LPMD_LOG_DEBUG))
+			return 1;
+		if (lpmd_write_str ("/sys/fs/cgroup/lpm/cpuset.cpus", get_cpu_isolation_str(state->cpumask_idx), LPMD_LOG_DEBUG))
 			return 1;
 	} else {
 		if (lpmd_write_str ("/sys/fs/cgroup/lpm/cpuset.cpus", get_cpu_isolation_str(CPUMASK_ONLINE), LPMD_LOG_DEBUG))

--- a/src/lpmd_helpers.c
+++ b/src/lpmd_helpers.c
@@ -252,6 +252,78 @@ int lpmd_read_int(const char *name, int *val, int print_level)
 
 }
 
+int lpmd_write_yn(const char *name, int val, int print_level)
+{
+	char str[5];
+	int ret;
+
+	if (!name)
+		return 0;
+
+	ret = snprintf(str, 4, "%d", val);
+	if (ret < 0)
+		return 1;
+
+	return _write_str (name, str, print_level, 2, "r+");
+}
+
+int lpmd_read_yn(const char *name, int *val, int print_level)
+{
+	char prefix[16];
+	FILE *filep;
+	int i, ret;
+
+	if (!name || !val)
+		return 1;
+
+	if (print_level >= 15)
+		return 1;
+
+	if (print_level < 0) {
+		prefix[0] = '\0';
+	}
+	else {
+		for (i = 0; i < print_level; i++)
+			prefix[i] = '\t';
+		prefix[i] = '\0';
+	}
+
+	filep = fopen (name, "r");
+	if (!filep) {
+		lpmd_log_error ("%sOpen %s failed\n", prefix, name);
+		return 1;
+	}
+
+	ret = fgetc(filep);
+	if (ret == EOF) {
+		if (feof(filep)) {
+			lpmd_log_error ("%sRead %s failed due to EOF\n", prefix, name);
+		} else if (ferror(filep)) {
+			lpmd_log_error ("%sRead %s failed, error %s\n", prefix, name, strerror(errno));
+		}
+		fclose (filep);
+		return 1;
+	}
+
+	fclose (filep);
+
+	if (ret == 'Y') {
+		*val = 1;
+	} else if (ret == 'N') {
+		*val = 0;
+	} else {
+		lpmd_log_error ("%sRead %s failed, read %c\n", prefix, name, ret);
+		return 1;
+	}
+
+	if (print_level >= 0)
+		lpmd_log_debug ("%sRead \"%c\" from %s\n", prefix, *val, name);
+
+	return 0;
+
+}
+
+
 /*
  * lpmd_open does not require print on success
  * print_level: -1: don't print on error

--- a/src/lpmd_misc.c
+++ b/src/lpmd_misc.c
@@ -21,7 +21,7 @@
 #include "lpmd.h"
 
 /* ITMT Management */
-#define PATH_ITMT_CONTROL "/proc/sys/kernel/sched_itmt_enabled"
+#define PATH_ITMT_CONTROL "/sys/kernel/debug/x86/sched_itmt_enabled"
 
 static int has_itmt;
 static int saved_itmt = SETTING_IGNORE;
@@ -33,13 +33,13 @@ int get_itmt(void)
 	if (!has_itmt)
 		return -1;
 
-	lpmd_read_int(PATH_ITMT_CONTROL, &val, -1);
+	lpmd_read_yn(PATH_ITMT_CONTROL, &val, -1);
 	return val;
 }
 
 int itmt_init(void)
 {
-	if (lpmd_read_int(PATH_ITMT_CONTROL, &saved_itmt, -1))
+	if (lpmd_read_yn(PATH_ITMT_CONTROL, &saved_itmt, -1))
 		lpmd_log_debug("ITMT not detected\n");
 	else
 		has_itmt = 1;
@@ -57,10 +57,10 @@ int process_itmt(lpmd_config_state_t *state)
 			lpmd_log_debug("Ignore ITMT\n");
 			return 0;
 		case SETTING_RESTORE:
-			return lpmd_write_int(PATH_ITMT_CONTROL, saved_itmt, -1);
+			return lpmd_write_yn(PATH_ITMT_CONTROL, saved_itmt, -1);
 		default:
 			lpmd_log_debug ("%s ITMT\n", state->itmt_state ? "Enable" : "Disable");
-			return lpmd_write_int(PATH_ITMT_CONTROL, state->itmt_state, -1);
+			return lpmd_write_yn(PATH_ITMT_CONTROL, state->itmt_state, -1);
 	}
 }
 

--- a/src/lpmd_proc.c
+++ b/src/lpmd_proc.c
@@ -150,6 +150,9 @@ static void power_profiles_changed_cb(void)
 		} else {
 			lpmd_log_warn("Ignore unsupported power profile: %s\n", active_profile);
 		}
+
+		if (lpmd_config.wlt_proxy_enable)
+			lpmd_config.data.polling_interval = DEF_POLLING_INTERVAL;
 	}
 }
 
@@ -300,7 +303,7 @@ static void* lpmd_core_main_loop(void *arg)
 {
 	int n;
 
-	lpmd_config.data.polling_interval = 100;
+	lpmd_config.data.polling_interval = DEF_POLLING_INTERVAL;
 
 	for (;;) {
 

--- a/src/lpmd_state_machine.c
+++ b/src/lpmd_state_machine.c
@@ -396,6 +396,14 @@ int lpmd_enter_next_state(void)
 	}
 
 	idx = choose_next_state(config);
+
+	/*
+	 * After switching power profiles polling gets disabled and needs to be
+	 * updated.
+	 */
+	if (config->data.polling_interval == -1 && polling_enabled && idx != DEFAULT_OFF)
+		get_config_state_interval(config, idx);
+
 	/* No action needed, keep previous idx and interval */
 	if (idx == STATE_NONE)
 		goto end;

--- a/src/lpmd_state_machine.c
+++ b/src/lpmd_state_machine.c
@@ -174,15 +174,15 @@ static int get_config_state_interval(lpmd_config_t *config, int idx)
 {
 	lpmd_config_state_t *state = &config->config_states[idx];
 
+	/* wlt proxy updates polling separately */
+	if (config->wlt_proxy_enable)
+		return 0;
+
 	/* Start polling only when needed */
 	if (!polling_enabled) {
 		config->data.polling_interval = -1;
 		return 0;
 	}
-
-	/* wlt proxy updates polling separately */
-	if (config->wlt_proxy_enable)
-		return 0;
 
 	/* Always start with minumum polling interval for a new state */
 	if (idx != current_idx) {


### PR DESCRIPTION
Bugs fixed:
- Proxy not working when regular polling is enabled
- Proxy not working when entering a power profile with DEFAULT_OFF state
- Isolated mode not working due to nothing written into cpuset.exclusive file
- ITMT not working after the sysfs file was moved to debugfs
- 16 core PTL config file (M204) specified 4 cores too many in the ActiveCPUs settings

Man pages update:
- Emphasize what's expected from the user when it comes to LPMD configuration
- Update generic information with things that changed since the man pages were last edited
- Move currently unused config options description to a separate section in the config man page.
- General formatting cleanup so the source code is easier to browse and edit