### PR TITLE
fix: prevent cgroup isolation churn during WLT polling

### DIFF
--- a/src/lpmd_cgroup.c
+++ b/src/lpmd_cgroup.c
@@ -170,6 +170,8 @@ static int process_cpu_cgroupv2(lpmd_config_state_t *state)
 	}
 }
 
+static enum cpumask_idx last_applied_cpumask = CPUMASK_NONE;
+
 /* Support for cgroup based cpu isolation */
 static int process_cpu_isolate(lpmd_config_state_t *state)
 {
@@ -193,6 +195,7 @@ static int process_cpu_isolate(lpmd_config_state_t *state)
 
 int cgroup_cleanup(void)
 {
+	last_applied_cpumask = CPUMASK_NONE;
 	DIR *dir = opendir("/sys/fs/cgroup/lpm");
 	if (dir) {
 		closedir(dir);
@@ -213,15 +216,28 @@ int cgroup_init(lpmd_config_t *config)
 
 int process_cgroup(lpmd_config_state_t *state, enum lpm_cpu_process_mode mode)
 {
+	int ret;
+
 	if (state->cpumask_idx == CPUMASK_NONE) {
 		lpmd_log_debug ("Ignore cgroup processing\n");
 		return 0;
 	}
 
+	if (last_applied_cpumask != CPUMASK_NONE &&
+	    cpumask_equal (state->cpumask_idx, last_applied_cpumask)) {
+		lpmd_log_debug ("Skip cgroup: cpumask unchanged\n");
+		return 0;
+	}
+
 	lpmd_log_info ("Process Cgroup ...\n");
 	if (mode == LPM_CPU_CGROUPV2)
-		return process_cpu_cgroupv2(state);
-	if (mode == LPM_CPU_ISOLATE)
-		return process_cpu_isolate(state);
-	return 0;
+		ret = process_cpu_cgroupv2(state);
+	else if (mode == LPM_CPU_ISOLATE)
+		ret = process_cpu_isolate(state);
+	else
+		ret = 0;
+
+	if (!ret)
+		last_applied_cpumask = state->cpumask_idx;
+	return ret;
 }


### PR DESCRIPTION
# Fix: Prevent cgroup isolation churn during WLT state flapping

## Platform
Intel Core Ultra 7 255H (Arrow Lake-H, Family 6 Model 197)  
Kernel: 6.17.0-22 — Ubuntu 24.04  
CPU layout: 0–5 = P-cores, 6–13 = E-cores, 14–15 = L-cores

---

## Problem

In Balanced (AUTO) mode with `Mode=1` (cgroup v2 isolate), P-cores were
not being parked despite the cgroup isolation appearing to apply correctly
at startup. CPUs 0–5 remained active and scheduled work even though the
config specified `ActiveCPUs=6-15` for all WLT states.

Power Saver mode (`PowersaverDef=1`, `LPMD_ON`) worked correctly — P-cores
parked at 400 MHz as expected. Only Balanced AUTO mode was affected.

---

## Root Cause

`process_cpu_isolate()` in `src/lpmd_cgroup.c` unconditionally executes
this sequence every time it is called:

```
cpuset.cpus.partition = member    ← un-isolates, briefly exposes P-cores
cpuset.cpus.exclusive = 0-5
cpuset.cpus.partition = isolated  ← re-isolates
cpuset.cpus             = 0-5
```

The `partition=member` write, even for milliseconds, returns CPUs 0–5 to
the root cgroup's effective CPU set. The kernel scheduler immediately
places waking tasks on them.

In AUTO mode, WLT (Workload Type) hints from the hardware flux rapidly —
multiple transitions per second between `UTIL_IDLE`, `UTIL_IDLE_BURSTY`,
and `UTIL_IDLE_GFX_BUSY`. Each transition causes `need_enter()` to return
true (it compares state indices, not cpumask content), which calls
`enter_state()`, which calls `process_cgroup()`, which calls
`process_cpu_isolate()` — re-running the destructive write sequence every
time.

In the `intel_lpmd_config_F6_M197.xml` config (implementing arrow-lake support RN)  
and Panther Lake M204 config, all four WLT states declare 
identical `ActiveCPUs` masks. So every WLT flip is pure churn: 
the cgroup is torn down and rebuilt withthe same content, many times per second. 
The P-cores are never stably parked — every `partition=member` write opens a 
scheduling window before the next `partition=isolated` closes it.

Power Saver was unaffected because `LPMD_ON` short-circuits to
`DEFAULT_ON` in `choose_next_state()`, bypassing WLT iteration entirely.
One stable cgroup entry, no flapping.

---

## Fix

Added a file-static `last_applied_cpumask` cache to `process_cgroup()`.
Before executing the cgroup write sequence, the function now compares the
requested cpumask against the last successfully applied one using the
existing `cpumask_equal()`. If the content is
identical, the write sequence is skipped entirely.

The cache is reset in `cgroup_cleanup()` so a subsequent daemon start
is never confused by stale state from a previous run.

---

## Verification

After the fix, in Balanced mode on the 255H:

- CPUs 0–5 (P-cores) hold at ~400 MHz under idle and light load
- `cat /sys/fs/cgroup/lpm/cpuset.cpus.partition` → `isolated` (stable)
- Debug log shows frequent `Skip cgroup: cpumask unchanged` and
  `Process Cgroup` fires only on genuine mask transitions
- Profile switches (Performance ↔ Balanced ↔ Power Saver) continue
  to apply correct isolation at each transition
- intel_lpmd_control ON|AUTO|OFF work continue to apply correct
  isolation at each transition