### PR TITLE
Fix build breakage with the last commit

### DIFF
--- a/src/lpmd_cgroup.c
+++ b/src/lpmd_cgroup.c
@@ -198,7 +198,7 @@ int cgroup_cleanup(void)
 	DIR *dir;
 
 	last_applied_cpumask = CPUMASK_NONE;
-	*dir = opendir("/sys/fs/cgroup/lpm");
+	dir = opendir("/sys/fs/cgroup/lpm");
 	if (dir) {
 		closedir(dir);
 		rmdir("/sys/fs/cgroup/lpm");


### PR DESCRIPTION
Last commit
"fix: prevent cgroup isolation churn during WLT polling "
introduced build error for *dir. Fix that.